### PR TITLE
Asx batch10

### DIFF
--- a/lib/Finance/Quote/ASX.pm
+++ b/lib/Finance/Quote/ASX.pm
@@ -6,6 +6,7 @@
 #    Copyright (C) 2000, Brent Neal <brentn@users.sourceforge.net>
 #    Copyright (C) 2001, Leigh Wedding <leigh.wedding@telstra.com>
 #    Copyright (C) 2000-2004, Paul Fenwick <pjf@cpan.org>
+#    Copyright (C) 2014, Chris Good <chris.good@@ozemail.com.au>
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -59,114 +60,120 @@ sub methods {return (australia => \&asx,asx => \&asx)}
 #
 # Maintainer of this section is Paul Fenwick <pjf@cpan.org>
 # 5-May-2001 Updated by Leigh Wedding <leigh.wedding@telstra.com>
+# 24-Feb-2014 Updated by Chris Good <chris.good@@ozemail.com.au>
 
 sub asx {
 	my $quoter = shift;
-	my @stocks = @_;
-	return unless @stocks;
+	my @all_stocks = @_;
+	return unless @all_stocks;
+	my @stocks;
 	my %info;
 
 	my $ua = $quoter->user_agent;
 
-	my $response = $ua->request(GET $ASX_URL.join("%20",@stocks));
-	unless ($response->is_success) {
-		foreach my $stock (@stocks) {
-			$info{$stock,"success"} = 0;
-			$info{$stock,"errormsg"} = "HTTP session failed";
-		}
-		return wantarray() ? %info : \%info;
-	}
+	# ASX webpage only handles up to 10 quote requests at once
 
-	my $te = HTML::TableExtract->new(
-		automap => 0,
-		headers => ["Code", "Last", '\+/-', "Bid", "Offer",
+	while (@stocks = splice(@all_stocks, 0, 10)) {
+		my $response = $ua->request(GET $ASX_URL.join("%20",@stocks));
+		unless ($response->is_success) {
+			foreach my $stock (@stocks) {
+				$info{$stock,"success"} = 0;
+				$info{$stock,"errormsg"} = "HTTP session failed";
+			}
+			return wantarray() ? %info : \%info;
+		}
+
+		my $te = HTML::TableExtract->new(
+			automap => 0,
+			headers => ["Code", "Last", '\+/-', "Bid", "Offer",
 		            "Open", "High", "Low", "Vol"]);
 
-	$te->parse($response->content);
+		$te->parse($response->content);
 
-	# Extract table contents.
-	my @rows;
-	unless (($te->tables > 0) && ( @rows = $te->rows)) {
-		foreach my $stock (@stocks) {
-			$info{$stock,"success"} = 0;
-			$info{$stock,"errormsg"} = "Failed to parse HTML table.";
-		}
-		return wantarray() ? %info : \%info;
-	}
-
-	# Pack the resulting data into our structure.
-	foreach my $row (@rows) {
-		my $stock = shift(@$row);
-
-		# Skip any blank lines.
-		next unless $stock;
-
-		# Delete spaces and '*' which sometimes appears after the code.
-		# Also delete high bit characters.
-		$stock =~ tr/* \200-\377//d;
-
-		# Delete any whitespace characters
-		$stock =~ s/\s//g;
-
-		$info{$stock,'symbol'} = $stock;
-
-		foreach my $label (qw/last p_change bid offer open
-			      high low volume/) {
-			$info{$stock,$label} = shift(@$row);
-
-			# Again, get rid of nasty high-bit characters.
-			$info{$stock,$label} =~ tr/ \200-\377//d
-				unless ($label eq "name");
-		}
-
-		# If that stock does not exist, it will have a empty
-		# string for all the fields.  The "last" price should
-		# always be defined (even if zero), if we see an empty
-		# string here then we know we've found a bogus stock.
-
-		if ($info{$stock,'last'} eq '') {
-			$info{$stock,'success'} = 0;
-			$info{$stock,'errormsg'}="Stock does not exist on ASX.";
-			next;
-		}
-
-		# Drop commas from volume.
-		$info{$stock,"volume"} =~ tr/,//d;
-
-		# The ASX returns zeros for a number of things if there
-		# has been no trading.  This not only looks silly, but
-		# can break things later.  "correct" zero'd data.
-
-		foreach my $label (qw/open high low/) {
-			if ($info{$stock,$label} == 0) {
-				$info{$stock,$label} = $info{$stock,"last"};
+		# Extract table contents.
+		my @rows;
+		unless (($te->tables > 0) && ( @rows = $te->rows)) {
+			foreach my $stock (@stocks) {
+				$info{$stock,"success"} = 0;
+				$info{$stock,"errormsg"} = "Failed to parse HTML table.";
 			}
+			return wantarray() ? %info : \%info;
 		}
 
-		# We get a dollar plus/minus change, rather than a
-		# percentage change, so we convert this into a
-		# percentage change, as required.  We should never have
-		# zero opening price, but if we do warn about it.
+		# Pack the resulting data into our structure.
+		foreach my $row (@rows) {
+			my $stock = shift(@$row);
 
-		if ($info{$stock,"open"} == 0) {
-			warn "Zero opening price in p_change calcuation for ".
-			     "stock $stock.  P_change set to zero.";
-			$info{$stock,"p_change"} = 0;
-		} else {
-			$info{$stock,"p_change"} = sprintf("%.2f",
-		                           ($info{$stock,"p_change"}*100)/
-				             $info{$stock,"open"});
+			# Skip any blank lines.
+			next unless $stock;
+
+			# Delete spaces and '*' which sometimes appears after the code.
+			# Also delete high bit characters.
+			$stock =~ tr/* \200-\377//d;
+
+			# Delete any whitespace characters
+			$stock =~ s/\s//g;
+
+			$info{$stock,'symbol'} = $stock;
+
+			foreach my $label (qw/last p_change bid offer open
+				      high low volume/) {
+				$info{$stock,$label} = shift(@$row);
+
+				# Again, get rid of nasty high-bit characters.
+				$info{$stock,$label} =~ tr/ \200-\377//d
+					unless ($label eq "name");
+			}
+
+			# If that stock does not exist, it will have a empty
+			# string for all the fields.  The "last" price should
+			# always be defined (even if zero), if we see an empty
+			# string here then we know we've found a bogus stock.
+
+			if ($info{$stock,'last'} eq '') {
+				$info{$stock,'success'} = 0;
+				$info{$stock,'errormsg'}="Stock does not exist on ASX.";
+				next;
+			}
+
+			# Drop commas from volume.
+			$info{$stock,"volume"} =~ tr/,//d;
+
+			# The ASX returns zeros for a number of things if there
+			# has been no trading.  This not only looks silly, but
+			# can break things later.  "correct" zero'd data.
+
+			foreach my $label (qw/open high low/) {
+				if ($info{$stock,$label} == 0) {
+					$info{$stock,$label} = $info{$stock,"last"};
+				}
+			}
+
+			# We get a dollar plus/minus change, rather than a
+			# percentage change, so we convert this into a
+			# percentage change, as required.  We should never have
+			# zero opening price, but if we do warn about it.
+
+			if ($info{$stock,"open"} == 0) {
+				warn "Zero opening price in p_change calcuation for ".
+				     "stock $stock.  P_change set to zero.";
+				$info{$stock,"p_change"} = 0;
+			} else {
+				$info{$stock,"p_change"} = sprintf("%.2f",
+			                           ($info{$stock,"p_change"}*100)/
+					             $info{$stock,"open"});
+			}
+
+			# Australian indexes all begin with X, so don't tag them
+			# as having currency info.
+
+			$info{$stock, "currency"} = "AUD" unless ($stock =~ /^X/);
+
+			$info{$stock, "method"} = "asx";
+			$info{$stock, "exchange"} = "Australian Stock Exchange";
+			$info{$stock, "price"} = $info{$stock,"last"};
+			$info{$stock, "success"} = 1;
 		}
-
-		# Australian indexes all begin with X, so don't tag them
-		# as having currency info.
-
-		$info{$stock, "currency"} = "AUD" unless ($stock =~ /^X/);
-
-		$info{$stock, "method"} = "asx";
-		$info{$stock, "exchange"} = "Australian Stock Exchange";
-		$info{$stock, "price"} = $info{$stock,"last"};
-		$info{$stock, "success"} = 1;
 	}
 
 	# All done.
@@ -223,3 +230,4 @@ Australian Stock Exchange, http://www.asx.com.au/
 Finance::Quote::Yahoo::Australia.
 
 =cut
+

--- a/t/asx.t
+++ b/t/asx.t
@@ -1,4 +1,8 @@
 #!/usr/bin/perl -w
+
+# 16-Feb-2014 Change RZR (delisted in 2012) to BOQ.
+# 28-Feb-2014 Add tests with 11 stocks at once. plan tests 11 -> 34.
+
 use strict;
 use Test::More;
 use Finance::Quote;
@@ -7,7 +11,7 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 11;
+plan tests => 34;
 
 # Test ASX functions.
 
@@ -45,5 +49,19 @@ unlike( $quotes{"BOQ","p_change"}
 
 # Check that looking up a bogus stock returns failure:
 %quotes = $q->asx("BOG");
-ok( ! $quotes{"BOG","success"}, "asx call for invalid stock returns failure");
+ok( ! $quotes{"BOG","success"}, "asx call for invalid stock BOG returns failure");
 
+# Check 11 stocks at once to test batching of price enquiries into groups of 10
+my @stocks = qw/AMP ANZ BHP BOQ BEN CSR IAG NAB TLS WBC WES/;
+
+%quotes = $q->asx(@stocks);
+ok( %quotes, "Data returned for call to asx" );
+
+# Check the last values are defined.  These are the most used and most
+# reliable indicators of success.
+
+foreach my $stock (@stocks) {
+	ok( $quotes{$stock, "success"}, $stock . " query was successful" );
+	cmp_ok( $quotes{$stock,"last"}, '>', 0
+	      , "Last price for " . $stock . " was > 0" );
+}


### PR DESCRIPTION
asx.t: 
1. Change RZR to BOQ as RZR was delisted in 2012
2. Add test for 11 stocks at once to test my mod to ASX.pm
ASX.pm: 
Batch price enquiries into groups of 10 as ASX website only handles 10 at once

These mods should enable the following cpan bugs to be closed:
93274 Can only get prices for 10 stocks at once from ASX
93046 bug 45052 should be closed 
45052 ASX quote stopped working

I haven't used github before so if I'm not doing something right, please let me know. Thanks.
