### PR TITLE
Hard coding currency for YahooJSON because yahoo doesnt include it in the JSON

### DIFF
--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -126,6 +126,17 @@ sub yahoo_json {
                 $info{ $stocks, "last" }   = $json_price;
                 $info{ $stocks, "volume" }   = $json_volume;
                 $info{ $stocks, "isodate" } = ( $json_utctime =~ /dddd-dd-dd/ );
+                my %suffix_to_currency = (
+                    NS => 'INR',
+                    CL => 'INR',
+                    BO => 'INR',
+                );
+
+                if (($stocks =~ m/([^.]+)\.([^.]+)/) ) {
+                    if (exists $suffix_to_currency{$2}) {
+                        $info{ $stocks, "currency" } = $suffix_to_currency{$2};
+                    }
+                }
 
                 $my_date = localtime($json_timestamp)->strftime('%d.%m.%Y %T');
                 if ( $json_utctime =~ /(\d\d\d\d)-(\d\d)-(\d\d)/ ) {

--- a/t/yahoojson.t
+++ b/t/yahoojson.t
@@ -10,7 +10,7 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 43;
+plan tests => 44;
 
 my $q = Finance::Quote->new();
 
@@ -54,6 +54,12 @@ foreach my $stock (@stocks) {
         my $date = $quotes{ $stock, "date" };
 
         # print "Date: $date ";
+
+		if ($stock =~ m/\.NS$/) {
+			my $currency = $quotes{$stock, "currency"};
+			ok($currency, "$stock has currency $currency");
+		}
+
     }
 }
 


### PR DESCRIPTION
I added a hash that maps the Stock Exchange suffix to a currency.  If the stock has a suffix in the hash, an extra currency field is passed back to the calling function.

This is all to work with GNUCash.  I dont have GNUCash so I havent tested it directly.

This patch is supposed to fix [102637](https://rt.cpan.org/Ticket/Display.html?id=102637)

Comments and suggestions to improve are welcome.