### PR TITLE
removing indirect object notation

### DIFF
--- a/lib/Finance/Quote/AEX.pm
+++ b/lib/Finance/Quote/AEX.pm
@@ -76,10 +76,10 @@ sub aex {
   $url = $AEX_URL;    		# base url
 
   # Create a user agent object and HTTP headers
-  my $ua  = new LWP::UserAgent(agent => 'Mozilla/4.0 (compatible; MSIE 5.5; Windows 98)');
+  my $ua = LWP::UserAgent->new(agent => 'Mozilla/4.0 (compatible; MSIE 5.5; Windows 98)');
 
   # Compose POST request
-  my $request = new HTTP::Request("GET", $url);
+  my $request = HTTP::Request->new("GET", $url);
 
   $reply = $ua->request( $request );
   #print Dumper $reply;

--- a/lib/Finance/Quote/AIAHK.pm
+++ b/lib/Finance/Quote/AIAHK.pm
@@ -69,7 +69,7 @@ sub aiahk {
     # Now parse the data table contained in the result.  This is the
     # inner of two tables.  There are no headers on this table as they
     # are part of the iframe containing this page.
-    $te= new HTML::TableExtract(depth => 1);
+    $te = HTML::TableExtract->new(depth => 1);
     $te->parse($reply->content);
 
     unless ($te->tables) {

--- a/lib/Finance/Quote/ASEGR.pm
+++ b/lib/Finance/Quote/ASEGR.pm
@@ -62,7 +62,7 @@ sub asegr {
 		if ($reply->is_success)
 		{
 
-			$te= new HTML::TableExtract( headers =>
+			$te= HTML::TableExtract->new( headers =>
 			[("Date","Price","\%Change","Volume","Max","Min","Value","Trades","Open")]);
 
 			$te->parse($reply->content);

--- a/lib/Finance/Quote/BMONesbittBurns.pm
+++ b/lib/Finance/Quote/BMONesbittBurns.pm
@@ -62,7 +62,7 @@ sub bmonesbittburns {
 
             #print STDERR $reply->content,"\n";
 
-            $te = new HTML::TableExtract( depth => 2);
+            $te = HTML::TableExtract->new( depth => 2);
 
             # parse table
             $te->parse($reply->content);

--- a/lib/Finance/Quote/BSERO.pm
+++ b/lib/Finance/Quote/BSERO.pm
@@ -63,7 +63,7 @@ sub bsero {
       if ($reply->is_success)
         {
 
-          $te = new HTML::TableExtract();
+          $te = HTML::TableExtract->new();
 
           $te->parse($reply->content);
 

--- a/lib/Finance/Quote/CSE.pm
+++ b/lib/Finance/Quote/CSE.pm
@@ -60,10 +60,10 @@ sub cse {
   $url = $CSE_URL;    		# base url
 
   # Create a user agent object and HTTP headers
-  my $ua  = new LWP::UserAgent(agent => 'Mozilla/4.0 (compatible; MSIE 5.5; Windows 98)');
+  my $ua = LWP::UserAgent->new(agent => 'Mozilla/4.0 (compatible; MSIE 5.5; Windows 98)');
 
   # Compose POST request
-  my $request = new HTTP::Request("GET", $url);
+  my $request = HTTP::Request->new("GET", $url);
 
   $reply = $ua->request( $request );
 

--- a/lib/Finance/Quote/Cdnfundlibrary.pm
+++ b/lib/Finance/Quote/Cdnfundlibrary.pm
@@ -62,7 +62,7 @@ sub fundlibrary   {
       $mutual = $_;
       $url = "$FUNDLIB_URL$mutual";
       $reply = $ua->request(GET $url);
-      $te = new HTML::TableExtract(headers => ["Date", "NAVPS"],
+      $te = HTML::TableExtract->new(headers => ["Date", "NAVPS"],
 				   slice_columns => 0);
 
       # Make sure something is returned  ##CAN exit more gracefully - add later##

--- a/lib/Finance/Quote/Deka.pm
+++ b/lib/Finance/Quote/Deka.pm
@@ -62,7 +62,7 @@ sub deka
       $info{$stock,"errormsg"} = "HTTP failure";
     } else {
       my @headers = [qw(Name ISIN Whg Datum)];
-      my $te = new HTML::TableExtract(headers => @headers, slice_columns => 0);
+      my $te = HTML::TableExtract->new(headers => @headers, slice_columns => 0);
       $te->parse($response->content);
       foreach my $ts ($te->table_states) {
 #        foreach my $row ($ts->rows) {

--- a/lib/Finance/Quote/FTPortfolios.pm
+++ b/lib/Finance/Quote/FTPortfolios.pm
@@ -71,7 +71,7 @@ sub ftportfolios
     @symbolhash{@symbols} = map(1,@symbols);
     #
     for (@symbols) {
-      my $te = new HTML::TableExtract( );
+      my $te = HTML::TableExtract->new();
       $trust = $_;
       $url = "$FTPORTFOLIOS_URL";
 

--- a/lib/Finance/Quote/FidelityFixed.pm
+++ b/lib/Finance/Quote/FidelityFixed.pm
@@ -67,7 +67,7 @@ sub fidelityfixed {
             next;
         }
 
-        $te = new HTML::TableExtract();
+        $te = HTML::TableExtract->new();
         $te->parse($response->content);
         #print "[debug]: (parsed HTML)",$te, "\n";
 

--- a/lib/Finance/Quote/FinanceCanada.pm
+++ b/lib/Finance/Quote/FinanceCanada.pm
@@ -64,7 +64,7 @@ sub financecanada {
 
 	# Parse the page looking for the table containing the full
 	# name of the stock
-        my $te = new HTML::TableExtract( depth => 2, count => 0);
+        my $te = HTML::TableExtract->new( depth => 2, count => 0);
         $te->parse($response->content);
 
 	# debug
@@ -87,7 +87,7 @@ sub financecanada {
 
 	# Parse the page looking for the table containing the quote
 	# details
-        $te = new HTML::TableExtract(headers => [qw(Quote)],
+        $te = HTML::TableExtract->new(headers => [qw(Quote)],
 				     slice_columns => 0);
         $te->parse($response->content);
 

--- a/lib/Finance/Quote/Finanzpartner.pm
+++ b/lib/Finance/Quote/Finanzpartner.pm
@@ -58,7 +58,7 @@ sub finanzpartner
 		if (!$response -> is_success()) {
 			$info{$stock,"errormsg"} = "HTTP failure";
 		} else {
-			my $te = new HTML::TableExtract(depth => 0, count => 2);
+			my $te = HTML::TableExtract->new(depth => 0, count => 2);
 			$te->parse($response->content);
 			my $table = $te->first_table_found;
 

--- a/lib/Finance/Quote/LeRevenu.pm
+++ b/lib/Finance/Quote/LeRevenu.pm
@@ -72,7 +72,7 @@ sub lerevenu {
 		{
 			# print STDERR $reply->content,"\n";
 
-			$te= new HTML::TableExtract( );
+			$te = HTML::TableExtract->new();
 
 			$te->parse($reply->content);
 

--- a/lib/Finance/Quote/Morningstar.pm
+++ b/lib/Finance/Quote/Morningstar.pm
@@ -41,7 +41,7 @@ sub morningstar {
 	  return wantarray ? %funds : \%funds;
     }
 
-    $te = new HTML::TableExtract();
+    $te = HTML::TableExtract->new();
     $te->parse($reply->content);
     #print "Tables: " . $te->tables_report() . "\n";
     my $counter = 0;

--- a/lib/Finance/Quote/StockHouseCanada.pm
+++ b/lib/Finance/Quote/StockHouseCanada.pm
@@ -115,7 +115,7 @@ sub stockhouse_fund  {
 		######################################################
 		# debug
 
-		#my $tetest= new HTML::TableExtract( headers => [qw(NAVPS CURRENCY)] );
+		#my $tetest= HTML::TableExtract->new( headers => [qw(NAVPS CURRENCY)] );
 		#$tetest->parse($reply->content);
 		#foreach my $tstest ($tetest->table_states) {
 		#    print "\n***\n*** Table (", join(',', $tstest->coords), "):\n***\n";
@@ -141,7 +141,7 @@ sub stockhouse_fund  {
 		$fundquote {$mutual, "name"} = $name;
 
 		# Find NAV and Currency via table header
-		my $te= new HTML::TableExtract( headers => [qw(NAVPS CURRENCY)] );
+		my $te = HTML::TableExtract->new( headers => [qw(NAVPS CURRENCY)] );
 		$te->parse($reply->content);
 
 		# There should only be one hit

--- a/lib/Finance/Quote/TSP.pm
+++ b/lib/Finance/Quote/TSP.pm
@@ -98,7 +98,7 @@ sub tsp {
 	$ua = $quoter->user_agent;
 	$reply = $ua->request(GET $TSP_URL);
 	return unless ($reply->is_success);
-	$te = new HTML::TableExtract( headers =>
+	$te = HTML::TableExtract->new( headers =>
 		["Date", values %TSP_FUND_COLUMNS] );
 
 	$te->parse($reply->content);

--- a/lib/Finance/Quote/Trustnet.pm
+++ b/lib/Finance/Quote/Trustnet.pm
@@ -72,7 +72,7 @@ sub trustnet
     @symbolhash{@symbols} = map(1,@symbols);
     #
     for (@symbols) {
-      my $te = new HTML::TableExtract( headers => [("Fund Name", "Group Name", "Bid Price", "Offer Price", "Yield")]);
+      my $te = HTML::TableExtract->new( headers => [("Fund Name", "Group Name", "Bid Price", "Offer Price", "Yield")]);
       $trust = $_;
       # determine unit type
       $unittype = "all";

--- a/lib/Finance/Quote/VWD.pm
+++ b/lib/Finance/Quote/VWD.pm
@@ -131,7 +131,7 @@ sub vwd {
             $title->find("span")->delete_content;
             $info{ $fund, "name" } = $title->as_trimmed_text;
 
-            my $te = new HTML::TableExtract( depth => 0, count => 0 );
+            my $te = HTML::TableExtract->new( depth => 0, count => 0 );
             $te->parse( $wpkurs->as_HTML );
             my $table = $te->first_table_found;
 

--- a/lib/Finance/Quote/ZA.pm
+++ b/lib/Finance/Quote/ZA.pm
@@ -68,7 +68,7 @@ sub sharenet {
             next;
         }
 
-        $te = new HTML::TableExtract();
+        $te = HTML::TableExtract->new();
         $te->parse( $response->content );
 
         # print "[debug]: (parsed HTML)",$te, "\n";

--- a/lib/Finance/Quote/ZA_UnitTrusts.pm
+++ b/lib/Finance/Quote/ZA_UnitTrusts.pm
@@ -61,7 +61,7 @@ sub za_unittrusts {
             next;
         }
 
-        $te = new HTML::TableExtract();
+        $te = HTML::TableExtract->new();
 
         $te->parse( $response->content );
 


### PR DESCRIPTION
Hello!

Thanks for taking the time to work on Finance::Quote! This is a very simple patch to replace any uses of indirect object notation:

    my $obj = new Some::Class

with the recommended Perl notation:

    my $obj = Some::Class->new

Hope it helps! Thanks!