### PR TITLE
YahooJSON.pm - Hardcode 'EUR' currency to several european stock market suffixes

### DIFF
--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -41,10 +41,21 @@ my %suffix_to_currency = (
     NS => 'INR',
     CL => 'INR',
     BO => 'INR',
-    BR => 'EUR',
-    PA => 'EUR',
-    BC => 'EUR',
-    MC => 'EUR',
+    BC => 'EUR',    # Barcelona, Spain
+    BI => 'EUR',    # Bilbao, Italy
+    BR => 'EUR',    # Brussels, Belgium
+    D  => 'EUR',    # Dusseldorf, Germany
+    F  => 'EUR',    # Frankfurt, Germany
+    H  => 'EUR',    # Hamburg, Germany        
+    HA => 'EUR',    # Hannover, Germany        
+    MA => 'EUR',    # Madrid, Spain        
+    MC => 'EUR',    # Madrid (M.C.), Spain
+    MI => 'EUR',    # Milano, Italy
+    MU => 'EUR',    # Munich, Germany        
+    PA => 'EUR',    # Paris, France
+    SG => 'EUR',    # Stuttgart, Germany        
+    VA => 'EUR',    # Valencia, Spain
+    VI => 'EUR',    # Vienna, Austria
 );
 
 sub methods {


### PR DESCRIPTION
In continuation of #31 :

Added several 'EUR' as currency to several other european stock market locations to the existing ones, following the listed abbreviations here:
http://search.cpan.org/dist/Finance-Quote/lib/Finance/Quote/Yahoo/Europe.pm

Suffixes '.CO' (Copenhagen, Denmark), '.L' (London, UK), '.O' (Oslo, Norway) and '.ST' (Stockholm, Sweden) trade in different currencies for which I do not know the abbreviation