### PR TITLE
[WIP] Initial pass at adding AlphaVantage module to Finance::Quote

### DIFF
--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -173,7 +173,7 @@ sub new {
   if (!@reqmodules or $reqmodules[0] eq "-defaults") {
     shift(@reqmodules) if (@reqmodules);
     # Default modules
-    @modules = qw/AEX AIAHK ASEGR ASX BMONesbittBurns BSERO Bourso
+    @modules = qw/AEX AIAHK AlphaVantage ASEGR ASX BMONesbittBurns BSERO Bourso
             Cdnfundlibrary Citywire CSE Currencies Deka DWS FTPortfolios Fidelity FidelityFixed
             FinanceCanada Fool FTfunds HU GoldMoney HEX IndiaMutual LeRevenu
             ManInvestments Morningstar MorningstarJP MStaruk NZX Platinum

--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -1,0 +1,65 @@
+#!/usr/bin/perl -w
+
+package Finance::Quote::AlphaVantage;
+
+require 5.005;
+
+use strict;
+use JSON qw( decode_json );
+use HTTP::Request::Common;
+
+my $ALPHAVANTAGE_URL = 'https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&interval=1min';
+my $ALPHAVANTAGE_API_KEY = $ENV{"ALPHAVANTAGE_API_KEY"};
+
+die "Expected ALPHAVANTAGE_API_KEY to be set; get an API key at https://www.alphavantage.co" unless (defined $ALPHAVANTAGE_API_KEY);
+
+sub methods {
+    return ( alphavantage => \&alphavantage,
+    );
+
+    my @labels = qw/date isodate open high low close volume/;
+
+    sub labels {
+        return ( alphavantage => \@labels,
+        );
+    }
+}
+
+sub alphavantage {
+    my $quoter = shift;
+    my @stocks = @_;
+    my ( %info, $reply, $url );
+    my $ua = $quoter->user_agent();
+
+    foreach my $stock (@stocks) {
+        $url = $ALPHAVANTAGE_URL . '&apikey=' . $ALPHAVANTAGE_API_KEY . '&symbol=' . $stock;
+        $reply = $ua->request(GET $url);
+
+        my $code = $reply->code;
+        my $desc = HTTP::Status::status_message($code);
+        my $body = $reply->content;
+
+        my $json_data = JSON::decode_json $body;
+        my ( $latest );
+
+        if ($json_data->{"Time Series (1min)"}) {
+            $info{ $stock, "success" } = 1;
+
+            $latest = (keys($json_data->{"Time Series (1min)"}))[0];
+
+            $info{ $stock, "open" } = $json_data->{"Time Series (1min)"}->{$latest}->{"1. open"};
+            $info{ $stock, "close" } = $json_data->{"Time Series (1min)"}->{$latest}->{"4. close"};
+            $info{ $stock, "high" } = $json_data->{"Time Series (1min)"}->{$latest}->{"2. high"};
+            $info{ $stock, "low" } = $json_data->{"Time Series (1min)"}->{$latest}->{"3. low"};
+            $info{ $stock, "volume" } = $json_data->{"Time Series (1min)"}->{$latest}->{"5. volume"};
+            $info{ $stock, "isodate" } = substr($latest, 0, 10);
+
+            $quoter->store_date( \%info, $stock, { isodate => $latest });
+        } else {
+            $info{ $stock, "success" } = 0;
+            $info{ $stock, "errormsg" } = $json_data->{"Error Message"} || $json_data->{"Information"};
+        }
+    }
+
+    return wantarray() ? %info : \%info;
+}

--- a/t/alphavantage.t
+++ b/t/alphavantage.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl -w
+use strict;
+use Test::More;
+use Finance::Quote;
+
+if (not $ENV{"ONLINE_TEST"}) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
+if (not $ENV{"ALPHAVANTAGE_API_KEY"}) {
+    plan skip_all => 'Set $ENV{ALPHAVANTAGE_API_KEY} to run this test; get one at https://www.alphavantage.co';
+}
+
+plan tests => 14;
+
+my $q = Finance::Quote->new();
+my $year = (localtime())[5] + 1900;
+my $lastyear = $year - 1;
+
+my %quotes = $q->alphavantage("IBM","CSCO","BOGUS");
+ok(%quotes);
+
+ok($quotes{"IBM","success"});
+ok($quotes{"IBM","open"} > 0);
+ok($quotes{"IBM","close"} > 0);
+ok($quotes{"IBM","high"} > 0);
+ok($quotes{"IBM","low"} > 0);
+ok($quotes{"IBM","volume"} > 0);
+ok(substr($quotes{"IBM","isodate"},0,4) == $year ||
+    substr($quotes{"IBM","isodate"},0,4) == $lastyear);
+ok(substr($quotes{"IBM","date"},6,4) == $year ||
+    substr($quotes{"IBM","date"},6,4) == $lastyear);
+
+ok($quotes{"CSCO","success"});
+ok($quotes{"CSCO","open"} > 0);
+ok($quotes{"CSCO","close"} > 0);
+ok($quotes{"CSCO","volume"} > 0);
+
+ok(! $quotes{"BOGUS","success"});


### PR DESCRIPTION
Hey there, like many others I was frustrated that Yahoo shut down their stock price API this week, thus rendering `Finance::Quote::Yahoo` unusable.

In the `finance-quote-devel` mailing list, @ecocode mentioned starting work on a dedicated module for [AlphaVantage](https://www.alphavantage.co) when time became available to him. While this is far from a finished product, I hope it provides a good enough start towards getting such a module included in `Finance::Quote`.

A couple notes:
- All of the tests for AlphaVantage pass given that `ALPHAVANTAGE_API_KEY` is set in the environment.
- I have not yet tried wiring this module up to GnuCash.
- I do not know if `Finance::Quote` has any opinions on how to store configuration such as an API key. I chose to use the environment because it was easy for me, but I'm not intimately familiar with how well that works on other platforms (specifically Windows).
- I definitely don't write Perl regularly, so the code itself could probably use some cleaning up. Large parts of it were unapologetically borrowed from the `Finance::Quote::YahooJSON` model. I am happy to take suggestions for how to improve the code, or to let someone else take this across the finish line.

Cheers!
-mattpatt