### PR TITLE
Stock quotes on London exchanges return values in pence not pounds an…

### DIFF
--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -126,6 +126,19 @@ sub yahoo_json {
 		$info{ $stocks, "currency"} = $json_resources->{'currency'};
                 $info{ $stocks, "volume" }   = $json_volume;
 
+                # The Yahoo JSON interface returns London prices in GBp (pence) instead of GBP (pounds)
+                # and the Yahoo Base had a hack to convert them to GBP.  In theory all the callers
+                # would correctly handle GBp as not the same as GBP, but they don't, and since
+                # we had the hack before, let's add it back now.
+                #
+                # Convert GBp or GBX to GBP (divide price by 100).
+
+                if ( ($info{$stocks,"currency"} eq "GBp") ||
+                     ($info{$stocks,"currency"} eq "GBX")) {
+                    $info{$stocks,"last"}=$info{$stocks,"last"}/100;
+                    $info{ $stocks, "currency"} = "GBP";
+                }
+            
                 $my_date =  localtime($json_timestamp)->strftime('%d.%m.%Y %T');
 
                 $quoter->store_date( \%info, $stocks,


### PR DESCRIPTION
…d use the identifier GBp instead of GBP.  The old Yahoo module, as well as other modules, have hacks to switch GBp to GBP quotes.

In theory it should be the caller doing this, but in practice they don't, and things like GnuCash see GBp and think GBP.   This means when you upgrade to 1.46 and switch your quotes from "yahoo" to "yahoo_json" you end up with incorrect prices.

The attached patch does the same hack as elsewhere and converts GBp (or GBX if Yahoo ever returns that instead) to GBP.

Addresses: https://rt.cpan.org/Public/Bug/Display.html?id=123630