### PR TITLE
AlphaVantage: add Helsinki stock exchange to currencies_by_suffix

### DIFF
--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -88,6 +88,7 @@ my %currencies_by_suffix = (
     '.MA'  => "EUR",    # 		Madrid
     '.VA'  => "EUR",    # 		Valence
     '.ST'  => "SEK",    # Sweden		Stockholm
+    '.HE'  => "EUR",    # Finland		Helsinki
     '.S'   => "CHF",    # Switzerland	Zurich
     '.TW'  => "TWD",    # Taiwan		Taiwan Stock Exchange
     '.TWO' => "TWD",    # 		OTC


### PR DESCRIPTION
Place it next to Stockholm since the entires don't appear to be sorted in any way.