### PR TITLE
yahooJSON.pm returns date 00/00/2000 in Windows

### DIFF
--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -736,26 +736,26 @@ sub store_date
     $this_month = $month;
     $year_specified = 0;
 
-    # Proces the inputs
-    if (defined $piecesref->{isodate}) {
+    # Process the inputs
+    if ((defined $piecesref->{isodate}) && ($piecesref->{isodate})) {
       ($year, $month, $day) = ($piecesref->{isodate} =~ m/(\d+)\W+(\w+)\W+(\d+)/);
       $year += 2000 if $year < 100;
       $year_specified = 1;
-#      printf ("ISO Date %s: Year %d, Month %s, Day %d\n", $piecesref->{isodate}, $year, $month, $day);
+#      printf "ISO Date %s: Year %d, Month %s, Day %d\n", $piecesref->{isodate}, $year, $month, $day;
     }
 
-    if (defined $piecesref->{usdate}) {
+    if ((defined $piecesref->{usdate}) && ($piecesref->{usdate})) {
       ($month, $day, $year) = ($piecesref->{usdate} =~ /(\w+)\W+(\d+)\W+(\d+)/);
       $year += 2000 if $year < 100;
       $year_specified = 1;
-#      printf ("US Date %s: Month %s, Day %d, Year %d\n", $piecesref->{usdate}, $month, $day, $year);
+#      printf "US Date %s: Month %s, Day %d, Year %d\n", $piecesref->{usdate}, $month, $day, $year;
     }
 
-    if (defined $piecesref->{eurodate}) {
-      ($day, $month, $year) = ($piecesref->{eurodate} =~ /(\d+)\W+(\w+)\W+(\d+)/);
+    if ((defined $piecesref->{eurodate}) && ($piecesref->{eurodate})) {
+        ($day, $month, $year) = ($piecesref->{eurodate} =~ /(\d+)\W+(\w+)\W+(\d+)/);
       $year += 2000 if $year < 100;
       $year_specified = 1;
-#      printf ("Euro Date %s: Day %d, Month %s, Year %d\n", $piecesref->{eurodate}, $day, $month, $year);
+#      printf "Euro Date %s: Day %d, Month %s, Year %d\n", $piecesref->{eurodate}, $day, $month, $year;
     }
 
     if (defined ($piecesref->{year})) {

--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -44,7 +44,7 @@ sub methods {
 }
 {
     my @labels = qw/name last date isodate volume currency method exchange type
-        div_yield eps pe year_range/;
+        div_yield eps pe year_range open high low close/;
 
     sub labels {
         return ( yahoo_json => \@labels,
@@ -152,6 +152,14 @@ sub yahoo_json {
                     sprintf("%12s - %s",
                         $json_resources->{"fiftyTwoWeekLow"},
                         $json_resources->{'fiftyTwoWeekHigh'});
+                $info{ $stocks, "open"} =
+                    $json_resources->{'regularMarketOpen'};
+                $info{ $stocks, "high"} =
+                    $json_resources->{'regularMarketDayHigh'};
+                $info{ $stocks, "low"} =
+                    $json_resources->{'regularMarketDayLow'};
+                $info{ $stocks, "close"} =
+                    $json_resources->{'regularMarketPreviousClose'};
 
                 # MS Windows strftime() does not support %T so use %H:%M:%S
                 #  instead.
@@ -205,7 +213,7 @@ This module provides the "yahoo_json" fetch method.
 
 The following labels may be returned by Finance::Quote::YahooJSON :
 name, last, isodate, volume, currency, method, exchange, type,
-div_yield eps pe year_range.
+div_yield eps pe year_range open high low close.
 
 =head1 SEE ALSO
 

--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -123,10 +123,13 @@ sub yahoo_json {
                 $info{ $stocks, "name" }   = $stocks . ' (' . $json_name . ')';
                 $info{ $stocks, "type" }   = $json_type;
                 $info{ $stocks, "last" }   = $json_price;
-		$info{ $stocks, "currency"} = $json_resources->{'currency'};
+                $info{ $stocks, "currency"} = $json_resources->{'currency'};
                 $info{ $stocks, "volume" }   = $json_volume;
 
-                $my_date =  localtime($json_timestamp)->strftime('%d.%m.%Y %T');
+                # MS Windows strftime() does not support %T so use %H:%M:%S
+                #  instead.
+                $my_date =
+                    localtime($json_timestamp)->strftime('%d.%m.%Y %H:%M:%S');
 
                 $quoter->store_date( \%info, $stocks,
                                      { eurodate => $my_date } );


### PR DESCRIPTION
1. MS Windows strftime() does not support %T so use equivalent %H:%M:%S instead.
2. Fix perl warnings which can cause GnuCash to hang when multiple quotes (>15) are requested.