### PR TITLE
Issue 80 ASX.pm m.asx.com.au no longer works

### DIFF
--- a/lib/Finance/Quote/ASX.pm
+++ b/lib/Finance/Quote/ASX.pm
@@ -47,6 +47,11 @@ use vars qw/$ASX_URL @ASX_SEC_CODES/;
 
 $ASX_URL = 'http://www.asx.com.au/asx/markets/priceLookup.do?by=asxCodes&asxCodes=';
 
+# These are the ASX codes starting with X that are securities not indexes
+#  and thus need currency AUD returned
+# See http://www.asx.com.au/asx/research/listedCompanies.do
+@ASX_SEC_CODES = (qw/XAM XIP XRO XPD XPE XF1 XRF XST XTD XTE XTV/);
+
 sub methods {return (australia => \&asx,asx => \&asx)}
 
 {

--- a/t/asx.t
+++ b/t/asx.t
@@ -11,7 +11,7 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 34;
+plan tests => 35;
 
 # Test ASX functions.
 
@@ -41,6 +41,12 @@ cmp_ok( $quotes{"BOQ","last"}, '>', 0
 # Check that we're getting currency information.
 cmp_ok( $quotes{"BOQ", "currency"}, "eq", "AUD"
       , "Currency of BOQ is AUD" );
+
+# Check that we're getting currency information from Share starting with X
+# which is NOT an index
+%quotes = $q->fetch("asx","XRO");
+cmp_ok( $quotes{"XRO", "currency"}, "eq", "AUD"
+      , "Currency of XRO is AUD" );
 
 # Check we're not getting bogus percentage signs.
 unlike( $quotes{"BOQ","p_change"}


### PR DESCRIPTION
Go back to www.asx.com.au/asx/markets/priceLookup.do which now works again.
Unfortunately the following fields are no longer available (not needed for GnuCash):
date, name, div_yield, eps, pe + year_range.
There is a date available but it is always today, so this script does not return it (GnuCash gnc-fq-helper will default it to today).
