### PR TITLE
update parsing for changed layout on dwsfunds source page

### DIFF
--- a/lib/Finance/Quote/DWS.pm
+++ b/lib/Finance/Quote/DWS.pm
@@ -127,9 +127,9 @@ sub dwsfunds {
 	if ($response->is_success) {
 		$html_string =$response->content;
 
-		$te = new HTML::TableExtract->new( depth => 3, count => 1 );
-		$te->parse($html_string);
-		$ts=$te->table_state(3,1);
+		$te = new HTML::TableExtract->new( attribs => { id => 'FundsFinder_ResultTable'} );
+                $te->parse($html_string);
+                $ts=$te->first_table_found();
 	} else {
 		# retrieval error - flag an error and return right away
 		foreach my $fund (@funds) {


### PR DESCRIPTION
Extracting the table from the [DWS funds source page](https://www.deami.de/dps/ff/prices.aspx) using depth and count does not work anymore (layout change). Therefore the source dwsfunds is broken.

The fix can be as follows:
- Extraction of the table using the table id "FundsFinder_ResultTable".
- Replacing the call of the [deprecated `table_state` method](http://search.cpan.org/dist/HTML-TableExtract/lib/HTML/TableExtract.pm#DEPRECATED_METHODS) by `first_table_found()`
