### PR TITLE
Handle JSE (Johannesburg) returned in ZAc

### DIFF
--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -139,6 +139,15 @@ sub yahoo_json {
                     $info{ $stocks, "currency"} = "GBP";
                 }
             
+	        # Apply the same hack for Johannesburg Stock Exchange (JSE) prices as they are returned in
+		# ZAc (cents) instead of ZAR (rands). JSE symbols are suffixed with ".JO" when querying 
+		# Yahoo e.g. ANG.JO
+		
+		if ( ($info{$stocks,"currency"} eq "ZAc") {
+                    $info{$stocks,"last"}=$info{$stocks,"last"}/100;
+                    $info{ $stocks, "currency"} = "ZAR";
+                }
+	    
                 $my_date =  localtime($json_timestamp)->strftime('%d.%m.%Y %T');
 
                 $quoter->store_date( \%info, $stocks,

--- a/t/yahoojson.t
+++ b/t/yahoojson.t
@@ -10,13 +10,13 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 67;
+plan tests => 75;
 
 my $q = Finance::Quote->new();
 
 #List of stocks to fetch. Feel free to change this during testing
 my @stocks =
-    ( "SUZLON.BO", "ANDHRABANK.BO", "RECLTD.NS", "AMZN", "SOLB.BR", "^DJI", "BEL20.BR", "INGDIRECTFNE.BC", "AENA.MC" );
+    ( "SUZLON.BO", "ANDHRABANK.BO", "RECLTD.NS", "AMZN", "SOLB.BR", "^DJI", "BEL20.BR", "INGDIRECTFNE.BC", "AENA.MC", "CFR.JO" );
 
 my %quotes = $q->fetch( "yahoo_json", @stocks );
 ok( %quotes, "Data returned" );
@@ -57,6 +57,9 @@ foreach my $stock (@stocks) {
         ok( $quotes { $stock, "currency" } eq 'INR', 'Bombay stocks have currency INR' ) if $stock =~ /\.BO$/ ;
         ok( $quotes { $stock, "currency" } eq 'EUR', 'Barcelona stocks have currency EUR' ) if $stock =~ /\.BC$/ ;
         ok( $quotes { $stock, "currency" } eq 'EUR', 'Madrid stocks have currency EUR' ) if $stock =~ /\.MC$/ ;
+
+        # currency for .JO (Johannesburg Stock Exchange) stocks
+        ok( $quotes { $stock, "currency" } eq 'ZAR', 'Johannesburg stocks have currency ZAR' ) if $stock =~ /\.JO$/ ;
 
         # print "Date: $date ";
     }


### PR DESCRIPTION
Yahoo JSON returns Johannesburg Stock Exchange (JSE) prices in ZAc (cents) which is not an ISO 4217 currency. This is required for GnuCash to correctly add prices to it's database.