### PR TITLE
Update Fidelity Direct source to make it functional

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -232,15 +232,20 @@
   testcases:
 #
 - module: Fidelity.pm
-  state: TBD
+  state: working
   added: TBD
-  changed: ~
+  changed: 2020-03-21
   removed: ~
   urls:
+    - https://fundresearch.fidelity.com/mutual-funds/fidelity-funds-daily-pricing-yields/download
   apikey: false
   notes: ~
-  testfile: TBD
+  testfile: fidelity.t
   testcases:
+    - FGRIX
+    - FNMIX
+    - FASGX
+    - FEQTX
 #
 - module: FidelityFixed.pm
   state: TBD

--- a/lib/Finance/Quote/Fidelity.pm
+++ b/lib/Finance/Quote/Fidelity.pm
@@ -37,7 +37,7 @@ use vars qw/$FIDELITY_URL /;
 use LWP::UserAgent;
 use HTTP::Request::Common;
 
-our $VERSION = '1.50'; # VERSION
+# VERSION
 
 $FIDELITY_URL = ("https://fundresearch.fidelity.com/mutual-funds/fidelity-funds-daily-pricing-yields/download");
 

--- a/lib/Finance/Quote/Fidelity.pm
+++ b/lib/Finance/Quote/Fidelity.pm
@@ -5,6 +5,7 @@
 #    Copyright (C) 2000, Yannick LE NY <y-le-ny@ifrance.com>
 #    Copyright (C) 2000, Paul Fenwick <pjf@cpan.org>
 #    Copyright (C) 2000, Brent Neal <brentn@users.sourceforge.net>
+#    Copyright (C) 2020, Caleb Begly <calebbegly@gmail.com>
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -36,9 +37,9 @@ use vars qw/$FIDELITY_URL /;
 use LWP::UserAgent;
 use HTTP::Request::Common;
 
-# VERSION
+our $VERSION = '1.50'; # VERSION
 
-$FIDELITY_URL = ("http://activequote.fidelity.com/nav/fulllist.csv");
+$FIDELITY_URL = ("https://fundresearch.fidelity.com/mutual-funds/fidelity-funds-daily-pricing-yields/download");
 
 sub methods {return (fidelity        => \&fidelity,
                      fidelity_direct => \&fidelity);}
@@ -74,8 +75,8 @@ sub fidelity
     if ($reply->is_success) {
       foreach (split('\015?\012',$reply->content)) {
 	my @q = $quoter->parse_csv($_) or next;
-
-	$sym = $q[2] or next;
+	
+	$sym = $q[1] or next;
 	$sym =~ s/^ +//;
 
     	# Skip symbols we didn't ask for.
@@ -86,14 +87,13 @@ sub fidelity
 	($aa {$sym, "name"}    	= $q[0]) =~ s/^\s+//;
 	 $aa {$sym, "name"}    	=~ s/\s+$//;
 	 $aa {$sym, "symbol"}  	= $sym;
-	($aa {$sym, "number"}  	= $q[1]) =~ s/^\s+//;
-	($aa {$sym, "nav"}     	= $q[4]) =~ s/^\s+// 	if defined($q[4]);
-	($aa {$sym, "div"}     	= $q[5]) =~ s/^\s+// 	if defined($q[5]);
-	($aa {$sym, "net"}     	= $q[6]) =~ s/^\s+// 	if defined($q[6]);
-	($aa {$sym, "p_change"} = $q[8]) =~ s/^\s+// 	if defined($q[8]);
-	($aa {$sym, "yield"}    = $q[9]) =~ s/^\s+// 	if defined($q[9]);
-	($aa {$sym, "yield"}    = $q[17]) =~ s/^\s+// 	if defined($q[17]);
-	 $aa {$sym, "price"}    = $aa{$sym, "nav"} 	if defined($q[4]);
+	($aa {$sym, "nav"}     	= $q[2]) =~ s/^\s+// 	if defined($q[2]);
+	($aa {$sym, "div"}     	= $q[3]) =~ s/^\s+// 	if defined($q[3]);
+	($aa {$sym, "p_change"} = $q[5]) =~ s/^\s+// 	if defined($q[5]);
+	($aa {$sym, "yield"}    = $q[6]) =~ s/^\s+// 	if defined($q[6]);
+	($aa {$sym, "yield"}    = $q[7]) =~ s/^\s+// 	if defined($q[7]);
+	($aa {$sym, "yield"}    = $q[8]) =~ s/^\s+// 	if defined($q[8]);
+	 $aa {$sym, "price"}    = $aa{$sym, "nav"} 	if defined($q[2]);
 	 $aa {$sym, "success"}  = 1;
 	 $aa {$sym, "currency"} = "USD";
 	 $quoter->store_date(\%aa, $sym, {usdate => $q[19]});
@@ -110,10 +110,6 @@ sub fidelity
 =head1 NAME
 
 Finance::Quote::Fidelity - Obtain information from Fidelity Investments.
-
-=head1 NOTE NOTE NOTE NOTE NOTE
-
-This module is currently non-functional.
 
 =head1 SYNOPSIS
 
@@ -142,12 +138,10 @@ Investment's terms and conditions.
 =head1 LABELS RETURNED
 
 The following labels may be returned by Finance::Quote::Fidelity:
-exchange, name, number, nav, change, ask, date, yield, price.
+exchange, name, nav, p_change, date, yield, price.
 
 =head1 SEE ALSO
 
 Fidelity Investments, http://www.fidelity.com/
-
-Finance::Quote::Yahoo::USA;
 
 =cut

--- a/t/fidelity.t
+++ b/t/fidelity.t
@@ -11,38 +11,35 @@ plan tests => 25;
 
 # Test Fidelity functions.
 
-TODO:{
-    local $TODO="To be debugged";
+my $q      = Finance::Quote->new();
+my @funds = qw/FGRIX FNMIX FASGX/;
+my $year = (localtime())[5] + 1900;
+my $lastyear = $year - 1;
 
-    my $q      = Finance::Quote->new();
-    my @funds = qw/FGRIX FNMIX FASGX/;
-    my $year = (localtime())[5] + 1900;
-    my $lastyear = $year - 1;
+my %quotes = $q->fidelity_direct(@funds);
+ok(%quotes);
 
-    my %quotes = $q->fidelity_direct(@funds);
-    ok(%quotes);
-
-    # Check that the name and nav are defined for all of the funds.
-    foreach my $fund (@funds) {
-        ok($quotes{$fund,"nav"} > 0);
-        ok(length($quotes{$fund,"name"}));
-        ok($quotes{$fund,"success"});
-        ok($quotes{$fund, "currency"} eq "USD");
-        ok(substr($quotes{$fund,"isodate"},0,4) == $year ||
-               substr($quotes{$fund,"isodate"},0,4) == $lastyear);
-        ok(substr($quotes{$fund,"date"},6,4) == $year ||
-               substr($quotes{$fund,"date"},6,4) == $lastyear);
-    }
-
-    # Some funds have yields instead of navs.  Check one of them too.
-    %quotes = $q->fidelity_direct("FSLXX");
-    ok(%quotes);
-    ok(length($quotes{"FSLXX","name"}));
-    ok($quotes{"FSLXX","yield"} > 0);
-    ok($quotes{"FSLXX","success"});
-    ok($quotes{"FSLXX", "currency"} eq "USD");
-
-    # Check that a bogus fund returns no-success.
-    %quotes = $q->fidelity_direct("BOGUS");
-    ok(! $quotes{"BOGUS","success"});
+# Check that the name and nav are defined for all of the funds.
+foreach my $fund (@funds) {
+    ok($quotes{$fund,"nav"} > 0);
+    ok(length($quotes{$fund,"name"}));
+    ok($quotes{$fund,"success"});
+    ok($quotes{$fund, "currency"} eq "USD");
+    ok(substr($quotes{$fund,"isodate"},0,4) == $year ||
+           substr($quotes{$fund,"isodate"},0,4) == $lastyear);
+    ok(substr($quotes{$fund,"date"},6,4) == $year ||
+           substr($quotes{$fund,"date"},6,4) == $lastyear);
 }
+
+# Some funds have yields instead of navs.  Check one of them too.
+%quotes = $q->fidelity_direct("FEQTX");
+ok(%quotes);
+ok(length($quotes{"FEQTX","name"}));
+ok($quotes{"FEQTX","yield"} > 0);
+ok($quotes{"FEQTX","success"});
+ok($quotes{"FEQTX", "currency"} eq "USD");
+
+# Check that a bogus fund returns no-success.
+%quotes = $q->fidelity_direct("BOGUS");
+ok(! $quotes{"BOGUS","success"});
+


### PR DESCRIPTION
- The old Fidelity link was broken, so I searched around and found the correct replacement which gives daily quotes for all Fidelity funds. 
- Some of the fields shifted around, so I updated the fields to match the new data source. One column (number) doesn't exist anymore, so I removed it (it's not needed by GnuCash).
- I updated the documentation to remove the note that this module isn't functional (since it is now functional).
- I tested that the module works with GnuCash 3.8b+ which I assume is the expected consumer of the information.
- The functionality can also be verified from a GNU cash install by running something similar to the following:
`perl gnc-fq-dump -v fidelity_direct FBGRX`