### PR TITLE
Bug fix: In the currency method, only calculate the inverse if possible.

### DIFF
--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -296,7 +296,9 @@ if ( $exchange_rate < 0.001 ) {
         local $^W = 0;
         return undef unless ( $exchange_rate + 0 );
     }
-    $exchange_rate = int( 100000000 / $inverse_rate + .5 ) / 100000000;
+    if ($inverse_rate != 0.0) {
+        $exchange_rate = int( 100000000 / $inverse_rate + .5 ) / 100000000;
+    }
 }
 
   return ($exchange_rate * $amount);


### PR DESCRIPTION
An inverse rate of 0.0 is sometimes fetched from Alphavantage, and this change allows F::Q to gracefully handle that.