### PR TITLE
Fetching quotes from XETRA (Frankfurt stock exchange)

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -2,17 +2,6 @@
 # vi: set filetype=yaml syntax=yaml noai ts=2 sw=2 ic:
 # state: working | failing | obsolete | removed
 ---
-- module: XETRA.pm
-  state: TBD
-  added: TBD
-  changed: ~
-  removed: ~
-  urls:
-  apikey: false
-  notes: ~
-  testfile: TBD
-  testcases:
-#
 - module: AEX.pm
   state: TBD
   added: TBD
@@ -698,6 +687,17 @@
   testcases:
 #
 - module: VWD.pm
+  state: TBD
+  added: TBD
+  changed: ~
+  removed: ~
+  urls:
+  apikey: false
+  notes: ~
+  testfile: TBD
+  testcases:
+#
+- module: XETRA.pm
   state: TBD
   added: TBD
   changed: ~

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1,7 +1,18 @@
 # Modules
-# vi: set filetype=yaml syntax=yaml noai ts=2 sw=2 ic:   
+# vi: set filetype=yaml syntax=yaml noai ts=2 sw=2 ic:
 # state: working | failing | obsolete | removed
 ---
+- module: XETRA.pm
+  state: TBD
+  added: TBD
+  changed: ~
+  removed: ~
+  urls:
+  apikey: false
+  notes: ~
+  testfile: TBD
+  testcases:
+#
 - module: AEX.pm
   state: TBD
   added: TBD
@@ -295,7 +306,7 @@
   added: 2001-05-08
   changed: 2019-06-21
   removed:
-  urls: 
+  urls:
     - http://caps.fool.com/Ticker/{$symbol}.aspx
   apikey: false
   notes: ~
@@ -375,7 +386,7 @@
   apikey: true
   notes: |
     Module retrieves data from IEX Trading (https://iextrading.com/).
-    For API Key - https://iextrading.com/developer/ and set the 
+    For API Key - https://iextrading.com/developer/ and set the
     environment variable IEXCLOUD_API_KEY.
   testfile: iexcloud.t
   testcases:
@@ -559,12 +570,12 @@
   added: 2005-03-02
   changed: 2019-06-09
   removed:
-  urls: 
+  urls:
     - https://www.tsp.gov/InvestmentFunds/FundPerformance/index.html
   apikey: false
-  notes: 
+  notes:
   testfile: tsp.t
-  testcases: 
+  testcases:
     - C
     - F
     - G
@@ -625,11 +636,11 @@
   testfile: tiaacref.t
   testcases:
     - CREFmony
-    - TIAAreal 
-    - TLSRX 
-    - TCMVX 
-    - TLGRX 
-    - CREFbond 
+    - TIAAreal
+    - TLSRX
+    - TCMVX
+    - TLGRX
+    - CREFbond
 #
 - module: Troweprice.pm
   state: TBD

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -185,7 +185,7 @@ sub new {
         MorningstarJP MStaruk NZX Platinum Oslobors SEB SIXfunds
         SIXshares StockHouseCanada TSP TSX Tdefunds Tdwaterhouse
         Tiaacref TNetuk Troweprice Trustnet Union USFedBonds VWD ZA
-        Cominvest Finanzpartner YahooJSON YahooYQL ZA_UnitTrusts/;
+        Cominvest Finanzpartner YahooJSON YahooYQL ZA_UnitTrusts XETRA/;
   }
 
   $this->_load_modules(@modules,@reqmodules);

--- a/lib/Finance/Quote/XETRA.pm
+++ b/lib/Finance/Quote/XETRA.pm
@@ -66,7 +66,7 @@ sub xetra {
         else {
             $info{ $stocks, "success" } = 0;
             $info{ $stocks, "errormsg" } = "Invalid format: use only one '.' to separate ISIN from MIC";
-            continue;
+            next;
         }
 
         my $url = $PRICE_URL . "?mic=" . $mic . "&isin=" . $isin;

--- a/lib/Finance/Quote/XETRA.pm
+++ b/lib/Finance/Quote/XETRA.pm
@@ -1,0 +1,128 @@
+#!/usr/bin/perl -w
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#    02110-1301, USA
+
+package Finance::Quote::XETRA;
+
+require 5.005;
+
+use strict;
+use JSON qw( decode_json );
+use vars qw($VERSION $YIND_URL_HEAD $YIND_URL_TAIL);
+use LWP::UserAgent;
+use HTTP::Request::Common;
+use HTML::TableExtract;
+use Time::Piece;
+
+# VERSION
+
+
+my $PRICE_URL = "https://api.boerse-frankfurt.de/data/price_information?mic=XETR&isin=";
+
+sub methods {
+    return ( xetra => \&xetra,
+    );
+}
+{
+    my @labels = qw/exchange symbol last high low isodate date close currency/;
+
+    sub labels {
+        return ( xetra => \@labels, );
+    }
+}
+
+sub xetra {
+
+    my $quoter = shift;
+    my @stocks = @_;
+    my ( %info, $reply, $url, $te, $ts, $row, @cells, $ce );
+    my $ua = $quoter->user_agent();
+
+    # server reply is a perpetual event stream with continuous updates
+    # disconnect after we receive the first event
+    $ua->max_size(10);
+
+    foreach my $stocks (@stocks) {
+        my $url = $PRICE_URL . $stocks;
+        my $resp = $ua->request(GET $url);
+        my $code = $resp->code;
+        my $desc = HTTP::Status::status_message($code);
+        my $len = length($resp->content);
+
+        $info{ $stocks, "symbol" } = $stocks;
+
+        if ( $code == 200 && $len > 5 ) {
+            my $payload = substr($resp->content, 5);
+            my $data = JSON::decode_json $payload;
+
+            $info{$stocks, 'success'} = 1;
+            $info{$stocks, 'method'} = 'xetra';
+            $info{$stocks, 'exchange'} = 'XETR';
+            $info{$stocks, 'symbol'} = $data->{'isin'};
+            $info{$stocks, 'last'} = $data->{'lastPrice'};
+            $info{$stocks, 'high'} = $data->{'dayHigh'};
+            $info{$stocks, 'low'} = $data->{'dayLow'};
+            $info{$stocks, 'close'} = $data->{'closingPricePrevTradingDay'};
+            $info{$stocks, 'currency'} = $data->{'currency'}{'originalValue'};
+
+            my $isodate = substr($data->{'timestampLastPrice'}, 0, 10);
+            $info{$stocks, 'isodate'} = $isodate;
+            $info{$stocks, 'date'} = substr($isodate, 5, 2) . "/" . substr($isodate, 8, 10) . "/" . substr($isodate, 0, 4);
+
+        }
+        else {
+            $info{ $stocks, "success" } = 0;
+            $info{ $stocks, "errormsg" } =
+                "Error retrieving quote for $stocks. Attempt to fetch the URL $url resulted in HTTP response $code ($desc) and body of length $len";
+        }
+
+    }
+
+    return wantarray() ? %info : \%info;
+    return \%info;
+}
+
+1;
+
+=head1 NAME
+
+Finance::Quote::XETRA - Obtain quotes from XETRA (Frankfurt Stock Exchange)
+
+=head1 SYNOPSIS
+
+    use Finance::Quote;
+
+    $q = Finance::Quote->new;
+
+    %info = Finance::Quote->fetch("xetra","EU0009658145");
+
+=head1 DESCRIPTION
+
+This module fetches information from the Frankfurt Stock Exchange.
+
+This module is loaded by default on a Finance::Quote object. It's
+also possible to load it explicitly by placing "XETRA" in the argument
+list to Finance::Quote->new().
+
+This module provides the "xetra" fetch method.
+
+=head1 LABELS RETURNED
+
+The following labels may be returned by Finance::Quote::XETRA :
+exchange symbol last high low isodate date close currency
+
+=head1 SEE ALSO
+
+=cut

--- a/lib/Finance/Quote/XETRA.pm
+++ b/lib/Finance/Quote/XETRA.pm
@@ -26,10 +26,8 @@ use HTTP::Request::Common;
 use HTML::TableExtract;
 use Time::Piece;
 
-# VERSION
 
-
-my $PRICE_URL = "https://api.boerse-frankfurt.de/data/price_information?mic=XETR&isin=";
+my $PRICE_URL = "https://api.boerse-frankfurt.de/data/price_information";
 
 sub methods {
     return ( xetra => \&xetra,
@@ -55,7 +53,23 @@ sub xetra {
     $ua->max_size(10);
 
     foreach my $stocks (@stocks) {
-        my $url = $PRICE_URL . $stocks;
+        my @parts = split /\./, $stocks;
+        my $isin = $parts[0];
+
+        my $mic;
+        if ( scalar @parts == 1 ) {
+            $mic = "XETR";
+        }
+        elsif ( scalar @parts == 2 ) {
+            $mic = $parts[1];
+        }
+        else {
+            $info{ $stocks, "success" } = 0;
+            $info{ $stocks, "errormsg" } = "Invalid format: use only one '.' to separate ISIN from MIC";
+            continue;
+        }
+
+        my $url = $PRICE_URL . "?mic=" . $mic . "&isin=" . $isin;
         my $resp = $ua->request(GET $url);
         my $code = $resp->code;
         my $desc = HTTP::Status::status_message($code);
@@ -69,7 +83,7 @@ sub xetra {
 
             $info{$stocks, 'success'} = 1;
             $info{$stocks, 'method'} = 'xetra';
-            $info{$stocks, 'exchange'} = 'XETR';
+            $info{$stocks, 'exchange'} = $mic;
             $info{$stocks, 'symbol'} = $data->{'isin'};
             $info{$stocks, 'last'} = $data->{'lastPrice'};
             $info{$stocks, 'high'} = $data->{'dayHigh'};
@@ -98,7 +112,7 @@ sub xetra {
 
 =head1 NAME
 
-Finance::Quote::XETRA - Obtain quotes from XETRA.
+Finance::Quote::XETRA - Obtain quotes from XETRA/XFRA.
 
 =head1 SYNOPSIS
 
@@ -106,15 +120,21 @@ Finance::Quote::XETRA - Obtain quotes from XETRA.
 
     $q = Finance::Quote->new;
 
-    %info = Finance::Quote->fetch("xetra","EU0009658145");
+    %info = Finance::Quote->fetch("xetra", "EU0009658145.XETR");
 
 =head1 DESCRIPTION
 
-This module fetches information from the XETRA exchange, also including ETFs.
+This module fetches information from the XETRA and XFRA exchange, also including ETFs.
 
-This module is loaded by default on a Finance::Quote object. It's
-also possible to load it explicitly by placing "XETRA" in the argument
-list to Finance::Quote->new().
+The desired exchange can be specified by appending 'XETR' or 'XFRA' after the ISIN,
+separating the two with a dot '.' (see synopsys).
+
+The full list of available symbols can be found at
+https://www.xetra.com/xetra-de/instrumente/alle-handelbaren-instrumente
+
+This module is loaded by default on a Finance::Quote object. It's also possible
+to load it explicitly by placing "XETRA" in the argument list to
+Finance::Quote->new().
 
 This module provides the "xetra" fetch method.
 

--- a/lib/Finance/Quote/XETRA.pm
+++ b/lib/Finance/Quote/XETRA.pm
@@ -98,7 +98,7 @@ sub xetra {
 
 =head1 NAME
 
-Finance::Quote::XETRA - Obtain quotes from XETRA (Frankfurt Stock Exchange)
+Finance::Quote::XETRA - Obtain quotes from XETRA.
 
 =head1 SYNOPSIS
 
@@ -110,7 +110,7 @@ Finance::Quote::XETRA - Obtain quotes from XETRA (Frankfurt Stock Exchange)
 
 =head1 DESCRIPTION
 
-This module fetches information from the Frankfurt Stock Exchange.
+This module fetches information from the XETRA exchange, also including ETFs.
 
 This module is loaded by default on a Finance::Quote object. It's
 also possible to load it explicitly by placing "XETRA" in the argument

--- a/t/xetra.t
+++ b/t/xetra.t
@@ -31,10 +31,13 @@ sub test_stock_success {
     my $exchange = $_[1] eq "" ? "XETR" : substr($_[1], 1);
     ok( $quotes{ $stock, "exchange" } eq $exchange, "exchange is correct" );
 
-    my @fields = ( "close", "high", "low", "last", "date", "isodate" );
+    my @fields = ( "close", "last", "date", "isodate" );
     foreach my $field (@fields) {
         ok( $quotes { $stock, $field }, $field . " is defined");
     }
+
+    ok( exists ( $quotes { $stock, "high" } ), "high key exists" );
+    ok( exists ( $quotes { $stock, "low" } ), "low key exists" );
 }
 
 my @stocks = ( "IE0031442068", "IE00B4L5YC18" );

--- a/t/xetra.t
+++ b/t/xetra.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl -w
+
+# A test script to check for working of the XETRA module.
+
+use strict;
+use Test::More;
+use Finance::Quote;
+use Data::Dumper;
+
+if (not $ENV{ONLINE_TEST}) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
+plan tests => 76;
+my $q = Finance::Quote->new();
+
+sub test_stock_success {
+    # arguments:
+    #   $_[0]: isin
+    #   $_[1]: exchange (starting with '.') or empty string
+
+    my $stock = $_[0] . $_[1];
+    my %quotes = $q->fetch( "xetra", $stock );
+
+    ok( %quotes, "Data returned" );
+    ok( $quotes{ $stock, "success" } == 1, "successful" );
+    ok( $quotes{ $stock, "symbol" } eq $_[0], "symbol matches" );
+    ok( $quotes{ $stock, "currency" } eq "EUR", "currency is euro" );
+    ok( $quotes{ $stock, "method" } eq "xetra", "method is correct" );
+
+    my $exchange = $_[1] eq "" ? "XETR" : substr($_[1], 1);
+    ok( $quotes{ $stock, "exchange" } eq $exchange, "exchange is correct" );
+
+    my @fields = ( "close", "high", "low", "last", "date", "isodate" );
+    foreach my $field (@fields) {
+        ok( $quotes { $stock, $field }, $field . " is defined");
+    }
+}
+
+my @stocks = ( "IE0031442068", "IE00B4L5YC18" );
+foreach my $stock (@stocks) {
+    test_stock_success( $stock, ".XFRA" );
+    test_stock_success( $stock, ".XETR" );
+    test_stock_success( $stock, "" );
+}
+
+my %qu1 = $q->fetch( "xetra", "ABC.DEF.GHI" );
+ok( $qu1{ "ABC.DEF.GHI", "success" } == 0, "wrong format fails" );
+ok( index( $qu1{ "ABC.DEF.GHI", "errormsg" }, "Invalid format" )  != -1, "descriptive error message" );
+
+my %qu2 = $q->fetch( "xetra", "notfound" );
+ok( $qu2{ "notfound", "success" } == 0, "not existing fails" );
+ok( index( $qu2{ "notfound", "errormsg" }, "HTTP response 400" )  != -1, "http code 400" );
+


### PR DESCRIPTION
Hi, I contributed a new module to fetch quotes from the [frankfurt stock exchange](https://www.xetra.com/xetra-en/), which provides a JSON endpoint. As I am new to perl, I based the module on `yahoo_json` and made the necessary modifications.

I don't know what is your policy on testing, but I can run the example script successfully:

```
$ perl stockdump.pl xetra DE000A0D8Q07
$VAR1 = {
          'DE000A0D8Q07exchange' => 'XETR',
          'DE000A0D8Q07high' => '35.42',
          'DE000A0D8Q07date' => '09/29/2020',
          'DE000A0D8Q07symbol' => 'DE000A0D8Q07',
          'DE000A0D8Q07isodate' => '2020-09-29',
          'DE000A0D8Q07method' => 'xetra',
          'DE000A0D8Q07close' => '35.445',
          'DE000A0D8Q07low' => '35.33',
          'DE000A0D8Q07last' => '35.42',
          'DE000A0D8Q07currency' => 'EUR',
          'DE000A0D8Q07success' => 1
        };

```

