### PR TITLE
Vanguard/AlphaVantage fixes

### DIFF
--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -247,6 +247,9 @@ sub alphavantage {
         #     }
         # }
 
+        # remove trailing percent sign, if present
+        $quote->{'10. change percent'} =~ s/\%$//;
+
         $info{ $stock, 'success' } = 1;
         $info{ $stock, 'success' }  = 1;
         $info{ $stock, 'symbol' }   = $quote->{'01. symbol'};

--- a/t/alphavantage.t
+++ b/t/alphavantage.t
@@ -32,6 +32,7 @@ foreach my $symbol (@symbols) {
     ok( $quotes{ $symbol, "high" } > 0, "$symbol returned high" );
     ok( $quotes{ $symbol, "low" } > 0, "$symbol returned low" );
     ok( $quotes{ $symbol, "volume" } >= 0, "$symbol returned volume" );
+    ok( $quotes{ $symbol, "p_change" } =~ /^[\-\.\d]+$/, "$symbol returned p_change" );
     ok(    substr( $quotes{ $symbol, "isodate" }, 0, 4 ) == $year
                || substr( $quotes{ $symbol, "isodate" }, 0, 4 ) == $lastyear );
     ok(    substr( $quotes{ $symbol, "date" }, 6, 4 ) == $year

--- a/t/vanguard.t
+++ b/t/vanguard.t
@@ -7,7 +7,12 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 26;
+if ( not $ENV{"ALPHAVANTAGE_API_KEY"} ) {
+    plan skip_all =>
+        'Set $ENV{ALPHAVANTAGE_API_KEY} to run this test; get one at https://www.alphavantage.co';
+}
+
+plan tests => 22;
 
 # Test Vanguard functions.
 
@@ -21,14 +26,15 @@ ok(%quotes);
 
 # Check that the name and last are defined for all of the funds.
 foreach my $fund (@funds) {
-	ok($quotes{$fund,"last"} > 0);
-	ok(length($quotes{$fund,"name"}));
-	ok($quotes{$fund,"success"});
-        ok($quotes{$fund, "currency"} eq "USD");
-	ok(substr($quotes{$fund,"isodate"},0,4) == $year ||
-	   substr($quotes{$fund,"isodate"},0,4) == $lastyear);
-	ok(substr($quotes{$fund,"date"},6,4) == $year ||
-	   substr($quotes{$fund,"date"},6,4) == $lastyear);
+    ok($quotes{$fund,"last"} > 0);
+    # vanguard() is now alias to alphavantage, which doesn't export name label
+    #ok(length($quotes{$fund,"name"}));
+    ok($quotes{$fund,"success"});
+    ok($quotes{$fund, "currency"} eq "USD");
+    ok(substr($quotes{$fund,"isodate"},0,4) == $year ||
+        substr($quotes{$fund,"isodate"},0,4) == $lastyear);
+    ok(substr($quotes{$fund,"date"},6,4) == $year ||
+        substr($quotes{$fund,"date"},6,4) == $lastyear);
 }
 
 # Make sure we're not getting spurious percentage signs.


### PR DESCRIPTION
It turns out the failure of `vanguard.t` was caused by behavior in AlphaVantage, as the `vanguard()` method is now simply an alias for `alphavantage()`. The `p_change` field was added in a fairly recent commit, but the trailing percent sign was not stripped off. This PR adds code to strip off the trailing percent sign. **I suppose this could be a potentially breaking change if anyone is currently using this value in production**. Surely it's not meant to be there, though?

Also, a test is added for the new `p_change` field, the Vanguard tests are skipped if the AV API key is not present, and a test is removed in `vanguard.t` which checks for a field not provided by AlphaVantage.