### PR TITLE
Data::Dumper and debugging code (was: Misc fixes)

### DIFF
--- a/lib/Finance/Quote/Currencies.pm
+++ b/lib/Finance/Quote/Currencies.pm
@@ -24,7 +24,7 @@ use LWP::UserAgent;
 use HTTP::Request::Common;
 use HTML::TableExtract;
 use Encode qw(decode);
-use Data::Dumper::Perltidy;
+#use Data::Dumper::Perltidy;
 
 @EXPORT_OK = qw( known_currencies fetch_live_currencies );
 # VERSION
@@ -993,11 +993,12 @@ sub fetch_live_currencies {
   return \%result;
 }
 
-unless (caller) {
-  my $hash = fetch_live_currencies();
-  $Data::Dumper::Sortkeys = 1;
-  print Dumper $hash;
-}
+# use of D::D goes against the package testing policy
+#unless (caller) {
+  #my $hash = fetch_live_currencies();
+  #$Data::Dumper::Sortkeys = 1;
+  #print Dumper $hash;
+#}
 
 1;
 

--- a/lib/Finance/Quote/Oslobors.pm
+++ b/lib/Finance/Quote/Oslobors.pm
@@ -6,7 +6,6 @@ require 5.004;
 use strict;
 use JSON qw( decode_json );
 use HTTP::Request::Common;
-use Data::Dumper;
 
 use vars qw( $OSLOBORS_COMPONENTS_URL );
 


### PR DESCRIPTION
There is a test specifically to check for `Data::Dumper` being loaded, so these need to be removed. Possibly better just to remove the lines altogether.