### PR TITLE
TIAA-CREF fix

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -630,20 +630,22 @@
 - module: Tiaacref.pm
   state: working
   added: 2000-05-14
-  changed: 2015-08-24
+  changed: 2020-10-11
   removed: ~
   urls:
-    - https://www.tiaa-cref.org/public/tcfpi/Export/InvestmentDetails?Details=DailyPerformance
+    - https://www.tiaa.org/public/investment-performance 
   apikey: false
   notes: ~
   testfile: tiaacref.t
   testcases:
-    - CREFmony
-    - TIAAreal
-    - TLSRX
-    - TCMVX
-    - TLGRX
-    - CREFbond
+    - QCBMIX
+    - TEMLX
+    - TLFIX
+    - TSBPX
+    - W156#
+    - W323#
+    - W464#
+    - W719#
 #
 - module: Troweprice.pm
   state: TBD

--- a/dist.ini
+++ b/dist.ini
@@ -41,6 +41,8 @@ skip = ^Test::Perl::Critic$
 [Prereqs / TestRequires]
 Test::More = 0
 Test::Pod = 0
+Time::Piece = 0
+Scalar::Util = 0
 
 [Git::NextVersion]
 first_version = 1.21

--- a/lib/Finance/Quote/Currencies.pm
+++ b/lib/Finance/Quote/Currencies.pm
@@ -44,21 +44,25 @@ my %currencies = (
     'AED' => {
         'country' => ['UNITED ARAB EMIRATES (THE)'],
         'name'    => 'UAE Dirham',
+        'code'    => 'AED',
         'number'  => '784'
     },
     'AFN' => {
         'country' => ['AFGHANISTAN'],
         'name'    => 'Afghani',
+        'code'    => 'AFN',
         'number'  => '971'
     },
     'ALL' => {
         'country' => ['ALBANIA'],
         'name'    => 'Lek',
+        'code'    => 'ALL',
         'number'  => '008'
     },
     'AMD' => {
         'country' => ['ARMENIA'],
         'name'    => 'Armenian Dram',
+        'code'    => 'AMD',
         'number'  => '051'
     },
     'ANG' => {
@@ -67,16 +71,19 @@ my %currencies = (
             'SINT MAARTEN (DUTCH PART)'
         ],
         'name'    => 'Netherlands Antillean Guilder',
+        'code'    => 'ANG',
         'number'  => '532'
     },
     'AOA' => {
         'country' => ['ANGOLA'],
         'name'    => 'Kwanza',
+        'code'    => 'AOA',
         'number'  => '973'
     },
     'ARS' => {
         'country' => ['ARGENTINA'],
         'name'    => 'Argentine Peso',
+        'code'    => 'ARS',
         'number'  => '032'
     },
     'AUD' => {
@@ -91,111 +98,133 @@ my %currencies = (
             'TUVALU'
         ],
         'name'    => 'Australian Dollar',
+        'code'    => 'AUD',
         'number'  => '036'
     },
     'AWG' => {
         'country' => ['ARUBA'],
         'name'    => 'Aruban Florin',
+        'code'    => 'AWG',
         'number'  => '533'
     },
     'AZN' => {
         'country' => ['AZERBAIJAN'],
         'name'    => 'Azerbaijanian Manat',
+        'code'    => 'AZN',
         'number'  => '944'
     },
     'BAM' => {
         'country' => ['BOSNIA AND HERZEGOVINA'],
         'name'    => 'Convertible Mark',
+        'code'    => 'BAM',
         'number'  => '977'
     },
     'BBD' => {
         'country' => ['BARBADOS'],
         'name'    => 'Barbados Dollar',
+        'code'    => 'BBD',
         'number'  => '052'
     },
     'BDT' => {
         'country' => ['BANGLADESH'],
         'name'    => 'Taka',
+        'code'    => 'BDT',
         'number'  => '050'
     },
     'BGN' => {
         'country' => ['BULGARIA'],
         'name'    => 'Bulgarian Lev',
+        'code'    => 'BGN',
         'number'  => '975'
     },
     'BHD' => {
         'country' => ['BAHRAIN'],
         'name'    => 'Bahraini Dinar',
+        'code'    => 'BHD',
         'number'  => '048'
     },
     'BIF' => {
         'country' => ['BURUNDI'],
         'name'    => 'Burundi Franc',
+        'code'    => 'BIF',
         'number'  => '108'
     },
     'BMD' => {
         'country' => ['BERMUDA'],
         'name'    => 'Bermudian Dollar',
+        'code'    => 'BMD',
         'number'  => '060'
     },
     'BND' => {
         'country' => ['BRUNEI DARUSSALAM'],
         'name'    => 'Brunei Dollar',
+        'code'    => 'BND',
         'number'  => '096'
     },
     'BOB' => {
         'country' => ['BOLIVIA (PLURINATIONAL STATE OF)'],
         'name'    => 'Boliviano',
+        'code'    => 'BOB',
         'number'  => '068'
     },
     'BOV' => {
         'country' => ['BOLIVIA (PLURINATIONAL STATE OF)'],
         'name'    => 'Mvdol',
+        'code'    => 'BOV',
         'number'  => '984'
     },
     'BRL' => {
         'country' => ['BRAZIL'],
         'name'    => 'Brazilian Real',
+        'code'    => 'BRL',
         'number'  => '986'
     },
     'BSD' => {
         'country' => ['BAHAMAS (THE)'],
         'name'    => 'Bahamian Dollar',
+        'code'    => 'BSD',
         'number'  => '044'
     },
     'BTN' => {
         'country' => ['BHUTAN'],
         'name'    => 'Ngultrum',
+        'code'    => 'BTN',
         'number'  => '064'
     },
     'BWP' => {
         'country' => ['BOTSWANA'],
         'name'    => 'Pula',
+        'code'    => 'BWP',
         'number'  => '072'
     },
     'BYN' => {
         'country' => ['BELARUS'],
         'name'    => 'Belarussian Ruble',
+        'code'    => 'BYN',
         'number'  => '933'
     },
     'BZD' => {
         'country' => ['BELIZE'],
         'name'    => 'Belize Dollar',
+        'code'    => 'BZD',
         'number'  => '084'
     },
     'CAD' => {
         'country' => ['CANADA'],
         'name'    => 'Canadian Dollar',
+        'code'    => 'CAD',
         'number'  => '124'
     },
     'CDF' => {
         'country' => ['CONGO (THE DEMOCRATIC REPUBLIC OF THE)'],
         'name'    => 'Congolese Franc',
+        'code'    => 'CDF',
         'number'  => '976'
     },
     'CHE' => {
         'country' => ['SWITZERLAND'],
         'name'    => 'WIR Euro',
+        'code'    => 'CHE',
         'number'  => '947'
     },
     'CHF' => {
@@ -204,66 +233,79 @@ my %currencies = (
             'SWITZERLAND'
         ],
         'name'    => 'Swiss Franc',
+        'code'    => 'CHF',
         'number'  => '756'
     },
     'CHW' => {
         'country' => ['SWITZERLAND'],
         'name'    => 'WIR Franc',
+        'code'    => 'CHW',
         'number'  => '948'
     },
     'CLF' => {
         'country' => ['CHILE'],
         'name'    => 'Unidad de Fomento',
+        'code'    => 'CLF',
         'number'  => '990'
     },
     'CLP' => {
         'country' => ['CHILE'],
         'name'    => 'Chilean Peso',
+        'code'    => 'CLP',
         'number'  => '152'
     },
     'CNY' => {
         'country' => ['CHINA'],
         'name'    => 'Yuan Renminbi',
+        'code'    => 'CNY',
         'number'  => '156'
     },
     'COP' => {
         'country' => ['COLOMBIA'],
         'name'    => 'Colombian Peso',
+        'code'    => 'COP',
         'number'  => '170'
     },
     'COU' => {
         'country' => ['COLOMBIA'],
         'name'    => 'Unidad de Valor Real',
+        'code'    => 'COU',
         'number'  => '970'
     },
     'CRC' => {
         'country' => ['COSTA RICA'],
         'name'    => 'Costa Rican Colon',
+        'code'    => 'CRC',
         'number'  => '188'
     },
     'CUC' => {
         'country' => ['CUBA'],
         'name'    => 'Peso Convertible',
+        'code'    => 'CUC',
         'number'  => '931'
     },
     'CUP' => {
         'country' => ['CUBA'],
         'name'    => 'Cuban Peso',
+        'code'    => 'CUP',
         'number'  => '192'
     },
     'CVE' => {
         'country' => ['CABO VERDE'],
         'name'    => 'Cabo Verde Escudo',
+        'code'    => 'CVE',
         'number'  => '132'
     },
     'CZK' => {
         'country' => ['CZECH REPUBLIC (THE)'],
         'name'    => 'Czech Koruna',
+        'code'    => 'CZK',
         'number'  => '203'
     },
     'DJF' => {
         'country' => ['DJIBOUTI'],
         'name'    => 'Djibouti Franc',
+        'code'    => 'DJF',
         'number'  => '262'
     },
     'DKK' => {
@@ -273,31 +315,37 @@ my %currencies = (
             'GREENLAND'
         ],
         'name'    => 'Danish Krone',
+        'code'    => 'DKK',
         'number'  => '208'
     },
     'DOP' => {
         'country' => ['DOMINICAN REPUBLIC (THE)'],
         'name'    => 'Dominican Peso',
+        'code'    => 'DOP',
         'number'  => '214'
     },
     'DZD' => {
         'country' => ['ALGERIA'],
         'name'    => 'Algerian Dinar',
+        'code'    => 'DZD',
         'number'  => '012'
     },
     'EGP' => {
         'country' => ['EGYPT'],
         'name'    => 'Egyptian Pound',
+        'code'    => 'EGP',
         'number'  => '818'
     },
     'ERN' => {
         'country' => ['ERITREA'],
         'name'    => 'Nakfa',
+        'code'    => 'ERN',
         'number'  => '232'
     },
     'ETB' => {
         'country' => ['ETHIOPIA'],
         'name'    => 'Ethiopian Birr',
+        'code'    => 'ETB',
         'number'  => '230'
     },
     'EUR' => {
@@ -339,16 +387,19 @@ my %currencies = (
             'SPAIN'
         ],
         'name'    => 'Euro',
+        'code'    => 'EUR',
         'number'  => '978'
     },
     'FJD' => {
         'country' => ['FIJI'],
         'name'    => 'Fiji Dollar',
+        'code'    => 'FJD',
         'number'  => '242'
     },
     'FKP' => {
         'country' => ['FALKLAND ISLANDS (THE) [MALVINAS]'],
         'name'    => 'Falkland Islands Pound',
+        'code'    => 'FKP',
         'number'  => '238'
     },
     'GBP' => {
@@ -359,76 +410,91 @@ my %currencies = (
             'UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND (THE)'
         ],
         'name'    => 'Pound Sterling',
+        'code'    => 'GBP',
         'number'  => '826'
     },
     'GEL' => {
         'country' => ['GEORGIA'],
         'name'    => 'Lari',
+        'code'    => 'GEL',
         'number'  => '981'
     },
     'GHS' => {
         'country' => ['GHANA'],
         'name'    => 'Ghana Cedi',
+        'code'    => 'GHS',
         'number'  => '936'
     },
     'GIP' => {
         'country' => ['GIBRALTAR'],
         'name'    => 'Gibraltar Pound',
+        'code'    => 'GIP',
         'number'  => '292'
     },
     'GMD' => {
         'country' => ['GAMBIA (THE)'],
         'name'    => 'Dalasi',
+        'code'    => 'GMD',
         'number'  => '270'
     },
     'GNF' => {
         'country' => ['GUINEA'],
         'name'    => 'Guinea Franc',
+        'code'    => 'GNF',
         'number'  => '324'
     },
     'GTQ' => {
         'country' => ['GUATEMALA'],
         'name'    => 'Quetzal',
+        'code'    => 'GTQ',
         'number'  => '320'
     },
     'GYD' => {
         'country' => ['GUYANA'],
         'name'    => 'Guyana Dollar',
+        'code'    => 'GYD',
         'number'  => '328'
     },
     'HKD' => {
         'country' => ['HONG KONG'],
         'name'    => 'Hong Kong Dollar',
+        'code'    => 'HKD',
         'number'  => '344'
     },
     'HNL' => {
         'country' => ['HONDURAS'],
         'name'    => 'Lempira',
+        'code'    => 'HNL',
         'number'  => '340'
     },
     'HRK' => {
         'country' => ['CROATIA'],
         'name'    => 'Kuna',
+        'code'    => 'HRK',
         'number'  => '191'
     },
     'HTG' => {
         'country' => ['HAITI'],
         'name'    => 'Gourde',
+        'code'    => 'HTG',
         'number'  => '332'
     },
     'HUF' => {
         'country' => ['HUNGARY'],
         'name'    => 'Forint',
+        'code'    => 'HUF',
         'number'  => '348'
     },
     'IDR' => {
         'country' => ['INDONESIA'],
         'name'    => 'Rupiah',
+        'code'    => 'IDR',
         'number'  => '360'
     },
     'ILS' => {
         'country' => ['ISRAEL'],
         'name'    => 'New Israeli Sheqel',
+        'code'    => 'ILS',
         'number'  => '376'
     },
     'INR' => {
@@ -437,111 +503,133 @@ my %currencies = (
             'INDIA'
         ],
         'name'    => 'Indian Rupee',
+        'code'    => 'INR',
         'number'  => '356'
     },
     'IQD' => {
         'country' => ['IRAQ'],
         'name'    => 'Iraqi Dinar',
+        'code'    => 'IQD',
         'number'  => '368'
     },
     'IRR' => {
         'country' => ['IRAN (ISLAMIC REPUBLIC OF)'],
         'name'    => 'Iranian Rial',
+        'code'    => 'IRR',
         'number'  => '364'
     },
     'ISK' => {
         'country' => ['ICELAND'],
         'name'    => 'Iceland Krona',
+        'code'    => 'ISK',
         'number'  => '352'
     },
     'JMD' => {
         'country' => ['JAMAICA'],
         'name'    => 'Jamaican Dollar',
+        'code'    => 'JMD',
         'number'  => '388'
     },
     'JOD' => {
         'country' => ['JORDAN'],
         'name'    => 'Jordanian Dinar',
+        'code'    => 'JOD',
         'number'  => '400'
     },
     'JPY' => {
         'country' => ['JAPAN'],
         'name'    => 'Yen',
+        'code'    => 'JPY',
         'number'  => '392'
     },
     'KES' => {
         'country' => ['KENYA'],
         'name'    => 'Kenyan Shilling',
+        'code'    => 'KES',
         'number'  => '404'
     },
     'KGS' => {
         'country' => ['KYRGYZSTAN'],
         'name'    => 'Som',
+        'code'    => 'KGS',
         'number'  => '417'
     },
     'KHR' => {
         'country' => ['CAMBODIA'],
         'name'    => 'Riel',
+        'code'    => 'KHR',
         'number'  => '116'
     },
     'KMF' => {
         'country' => ['COMOROS (THE)'],
         'name'    => 'Comoro Franc',
+        'code'    => 'KMF',
         'number'  => '174'
     },
     'KPW' => {
         'country' => ['KOREA (THE DEMOCRATIC PEOPLE’S REPUBLIC OF)'],
         'name'    => 'North Korean Won',
+        'code'    => 'KPW',
         'number'  => '408'
     },
     'KRW' => {
         'country' => ['KOREA (THE REPUBLIC OF)'],
         'name'    => 'Won',
+        'code'    => 'KRW',
         'number'  => '410'
     },
     'KWD' => {
         'country' => ['KUWAIT'],
         'name'    => 'Kuwaiti Dinar',
+        'code'    => 'KWD',
         'number'  => '414'
     },
     'KYD' => {
         'country' => ['CAYMAN ISLANDS (THE)'],
         'name'    => 'Cayman Islands Dollar',
+        'code'    => 'KYD',
         'number'  => '136'
     },
     'KZT' => {
         'country' => ['KAZAKHSTAN'],
         'name'    => 'Tenge',
+        'code'    => 'KZT',
         'number'  => '398'
     },
     'LAK' => {
         'country' => ['LAO PEOPLE’S DEMOCRATIC REPUBLIC (THE)'],
         'name'    => 'Kip',
+        'code'    => 'LAK',
         'number'  => '418'
     },
     'LBP' => {
         'country' => ['LEBANON'],
         'name'    => 'Lebanese Pound',
+        'code'    => 'LBP',
         'number'  => '422'
     },
     'LKR' => {
         'country' => ['SRI LANKA'],
         'name'    => 'Sri Lanka Rupee',
+        'code'    => 'LKR',
         'number'  => '144'
     },
     'LRD' => {
         'country' => ['LIBERIA'],
         'name'    => 'Liberian Dollar',
+        'code'    => 'LRD',
         'number'  => '430'
     },
     'LSL' => {
         'country' => ['LESOTHO'],
         'name'    => 'Loti',
+        'code'    => 'LSL',
         'number'  => '426'
     },
     'LYD' => {
         'country' => ['LIBYA'],
         'name'    => 'Libyan Dinar',
+        'code'    => 'LYD',
         'number'  => '434'
     },
     'MAD' => {
@@ -550,91 +638,109 @@ my %currencies = (
             'WESTERN SAHARA'
         ],
         'name'    => 'Moroccan Dirham',
+        'code'    => 'MAD',
         'number'  => '504'
     },
     'MDL' => {
         'country' => ['MOLDOVA (THE REPUBLIC OF)'],
         'name'    => 'Moldovan Leu',
+        'code'    => 'MDL',
         'number'  => '498'
     },
     'MGA' => {
         'country' => ['MADAGASCAR'],
         'name'    => 'Malagasy Ariary',
+        'code'    => 'MGA',
         'number'  => '969'
     },
     'MKD' => {
         'country' => ['REPUBLIC OF NORTH MACEDONIA'],
         'name'    => 'Denar',
+        'code'    => 'MKD',
         'number'  => '807'
     },
     'MMK' => {
         'country' => ['MYANMAR'],
         'name'    => 'Kyat',
+        'code'    => 'MMK',
         'number'  => '104'
     },
     'MNT' => {
         'country' => ['MONGOLIA'],
         'name'    => 'Tugrik',
+        'code'    => 'MNT',
         'number'  => '496'
     },
     'MOP' => {
         'country' => ['MACAO'],
         'name'    => 'Pataca',
+        'code'    => 'MOP',
         'number'  => '446'
     },
     'MRU' => {
         'country' => ['MAURITANIA'],
         'name'    => 'Ouguiya',
+        'code'    => 'MRU',
         'number'  => '929'
     },
     'MUR' => {
         'country' => ['MAURITIUS'],
         'name'    => 'Mauritius Rupee',
+        'code'    => 'MUR',
         'number'  => '480'
     },
     'MVR' => {
         'country' => ['MALDIVES'],
         'name'    => 'Rufiyaa',
+        'code'    => 'MVR',
         'number'  => '462'
     },
     'MWK' => {
         'country' => ['MALAWI'],
         'name'    => 'Kwacha',
+        'code'    => 'MWK',
         'number'  => '454'
     },
     'MXN' => {
         'country' => ['MEXICO'],
         'name'    => 'Mexican Peso',
+        'code'    => 'MXN',
         'number'  => '484'
     },
     'MXV' => {
         'country' => ['MEXICO'],
         'name'    => 'Mexican Unidad de Inversion (UDI)',
+        'code'    => 'MXV',
         'number'  => '979'
     },
     'MYR' => {
         'country' => ['MALAYSIA'],
         'name'    => 'Malaysian Ringgit',
+        'code'    => 'MYR',
         'number'  => '458'
     },
     'MZN' => {
         'country' => ['MOZAMBIQUE'],
         'name'    => 'Mozambique Metical',
+        'code'    => 'MZN',
         'number'  => '943'
     },
     'NAD' => {
         'country' => ['NAMIBIA'],
         'name'    => 'Namibia Dollar',
+        'code'    => 'NAD',
         'number'  => '516'
     },
     'NGN' => {
         'country' => ['NIGERIA'],
         'name'    => 'Naira',
+        'code'    => 'NGN',
         'number'  => '566'
     },
     'NIO' => {
         'country' => ['NICARAGUA'],
         'name'    => 'Cordoba Oro',
+        'code'    => 'NIO',
         'number'  => '558'
     },
     'NOK' => {
@@ -644,11 +750,13 @@ my %currencies = (
             'SVALBARD AND JAN MAYEN'
         ],
         'name'    => 'Norwegian Krone',
+        'code'    => 'NOK',
         'number'  => '578'
     },
     'NPR' => {
         'country' => ['NEPAL'],
         'name'    => 'Nepalese Rupee',
+        'code'    => 'NPR',
         'number'  => '524'
     },
     'NZD' => {
@@ -660,201 +768,241 @@ my %currencies = (
             'TOKELAU'
         ],
         'name'    => 'New Zealand Dollar',
+        'code'    => 'NZD',
         'number'  => '554'
     },
     'OMR' => {
         'country' => ['OMAN'],
         'name'    => 'Rial Omani',
+        'code'    => 'OMR',
         'number'  => '512'
     },
     'PAB' => {
         'country' => ['PANAMA'],
         'name'    => 'Balboa',
+        'code'    => 'PAB',
         'number'  => '590'
     },
     'PEN' => {
         'country' => ['PERU'],
         'name'    => 'Nuevo Sol',
+        'code'    => 'PEN',
         'number'  => '604'
     },
     'PGK' => {
         'country' => ['PAPUA NEW GUINEA'],
         'name'    => 'Kina',
+        'code'    => 'PGK',
         'number'  => '598'
     },
     'PHP' => {
         'country' => ['PHILIPPINES (THE)'],
         'name'    => 'Philippine Peso',
+        'code'    => 'PHP',
         'number'  => '608'
     },
     'PKR' => {
         'country' => ['PAKISTAN'],
         'name'    => 'Pakistan Rupee',
+        'code'    => 'PKR',
         'number'  => '586'
     },
     'PLN' => {
         'country' => ['POLAND'],
         'name'    => 'Zloty',
+        'code'    => 'PLN',
         'number'  => '985'
     },
     'PYG' => {
         'country' => ['PARAGUAY'],
         'name'    => 'Guarani',
+        'code'    => 'PYG',
         'number'  => '600'
     },
     'QAR' => {
         'country' => ['QATAR'],
         'name'    => 'Qatari Rial',
+        'code'    => 'QAR',
         'number'  => '634'
     },
     'RON' => {
         'country' => ['ROMANIA'],
         'name'    => 'Romanian Leu',
+        'code'    => 'RON',
         'number'  => '946'
     },
     'RSD' => {
         'country' => ['SERBIA'],
         'name'    => 'Serbian Dinar',
+        'code'    => 'RSD',
         'number'  => '941'
     },
     'RUB' => {
         'country' => ['RUSSIAN FEDERATION (THE)'],
         'name'    => 'Russian Ruble',
+        'code'    => 'RUB',
         'number'  => '643'
     },
     'RWF' => {
         'country' => ['RWANDA'],
         'name'    => 'Rwanda Franc',
+        'code'    => 'RWF',
         'number'  => '646'
     },
     'SAR' => {
         'country' => ['SAUDI ARABIA'],
         'name'    => 'Saudi Riyal',
+        'code'    => 'SAR',
         'number'  => '682'
     },
     'SBD' => {
         'country' => ['SOLOMON ISLANDS'],
         'name'    => 'Solomon Islands Dollar',
+        'code'    => 'SBD',
         'number'  => '090'
     },
     'SCR' => {
         'country' => ['SEYCHELLES'],
         'name'    => 'Seychelles Rupee',
+        'code'    => 'SCR',
         'number'  => '690'
     },
     'SDG' => {
         'country' => ['SUDAN (THE)'],
         'name'    => 'Sudanese Pound',
+        'code'    => 'SDG',
         'number'  => '938'
     },
     'SEK' => {
         'country' => ['SWEDEN'],
         'name'    => 'Swedish Krona',
+        'code'    => 'SEK',
         'number'  => '752'
     },
     'SGD' => {
         'country' => ['SINGAPORE'],
         'name'    => 'Singapore Dollar',
+        'code'    => 'SGD',
         'number'  => '702'
     },
     'SHP' => {
         'country' => ['SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA'],
         'name'    => 'Saint Helena Pound',
+        'code'    => 'SHP',
         'number'  => '654'
     },
     'SLL' => {
         'country' => ['SIERRA LEONE'],
         'name'    => 'Leone',
+        'code'    => 'SLL',
         'number'  => '694'
     },
     'SOS' => {
         'country' => ['SOMALIA'],
         'name'    => 'Somali Shilling',
+        'code'    => 'SOS',
         'number'  => '706'
     },
     'SRD' => {
         'country' => ['SURINAME'],
         'name'    => 'Surinam Dollar',
+        'code'    => 'SRD',
         'number'  => '968'
     },
     'SSP' => {
         'country' => ['SOUTH SUDAN'],
         'name'    => 'South Sudanese Pound',
+        'code'    => 'SSP',
         'number'  => '728'
     },
     'STN' => {
         'country' => ['SAO TOME AND PRINCIPE'],
         'name'    => 'Dobra',
+        'code'    => 'STN',
         'number'  => '930'
     },
     'SVC' => {
         'country' => ['EL SALVADOR'],
         'name'    => 'El Salvador Colon',
+        'code'    => 'SVC',
         'number'  => '222'
     },
     'SYP' => {
         'country' => ['SYRIAN ARAB REPUBLIC'],
         'name'    => 'Syrian Pound',
+        'code'    => 'SYP',
         'number'  => '760'
     },
     'SZL' => {
         'country' => ['SWAZILAND'],
         'name'    => 'Lilangeni',
+        'code'    => 'SZL',
         'number'  => '748'
     },
     'THB' => {
         'country' => ['THAILAND'],
         'name'    => 'Baht',
+        'code'    => 'THB',
         'number'  => '764'
     },
     'TJS' => {
         'country' => ['TAJIKISTAN'],
         'name'    => 'Somoni',
+        'code'    => 'TJS',
         'number'  => '972'
     },
     'TMT' => {
         'country' => ['TURKMENISTAN'],
         'name'    => 'Turkmenistan New Manat',
+        'code'    => 'TMT',
         'number'  => '934'
     },
     'TND' => {
         'country' => ['TUNISIA'],
         'name'    => 'Tunisian Dinar',
+        'code'    => 'TND',
         'number'  => '788'
     },
     'TOP' => {
         'country' => ['TONGA'],
         'name'    => 'Pa’anga',
+        'code'    => 'TOP',
         'number'  => '776'
     },
     'TRY' => {
         'country' => ['TURKEY'],
         'name'    => 'Turkish Lira',
+        'code'    => 'TRY',
         'number'  => '949'
     },
     'TTD' => {
         'country' => ['TRINIDAD AND TOBAGO'],
         'name'    => 'Trinidad and Tobago Dollar',
+        'code'    => 'TTD',
         'number'  => '780'
     },
     'TWD' => {
         'country' => ['TAIWAN (PROVINCE OF CHINA)'],
         'name'    => 'New Taiwan Dollar',
+        'code'    => 'TWD',
         'number'  => '901'
     },
     'TZS' => {
         'country' => ['TANZANIA, UNITED REPUBLIC OF'],
         'name'    => 'Tanzanian Shilling',
+        'code'    => 'TZS',
         'number'  => '834'
     },
     'UAH' => {
         'country' => ['UKRAINE'],
         'name'    => 'Hryvnia',
+        'code'    => 'UAH',
         'number'  => '980'
     },
     'UGX' => {
         'country' => ['UGANDA'],
         'name'    => 'Uganda Shilling',
+        'code'    => 'UGX',
         'number'  => '800'
     },
     'USD' => {
@@ -880,46 +1028,55 @@ my %currencies = (
             'VIRGIN ISLANDS (U.S.)'
         ],
         'name'    => 'US Dollar',
+        'code'    => 'USD',
         'number'  => '840'
     },
     'USN' => {
         'country' => ['UNITED STATES OF AMERICA (THE)'],
         'name'    => 'US Dollar (Next day)',
+        'code'    => 'USN',
         'number'  => '997'
     },
     'UYI' => {
         'country' => ['URUGUAY'],
         'name'    => 'Uruguay Peso en Unidades Indexadas (URUIURUI)',
+        'code'    => 'UYI',
         'number'  => '940'
     },
     'UYU' => {
         'country' => ['URUGUAY'],
         'name'    => 'Peso Uruguayo',
+        'code'    => 'UYU',
         'number'  => '858'
     },
     'UZS' => {
         'country' => ['UZBEKISTAN'],
         'name'    => 'Uzbekistan Sum',
+        'code'    => 'UZS',
         'number'  => '860'
     },
     'VEF' => {
         'country' => ['VENEZUELA (BOLIVARIAN REPUBLIC OF)'],
         'name'    => 'Bolivar',
+        'code'    => 'VEF',
         'number'  => '937'
     },
     'VND' => {
         'country' => ['VIET NAM'],
         'name'    => 'Dong',
+        'code'    => 'VND',
         'number'  => '704'
     },
     'VUV' => {
         'country' => ['VANUATU'],
         'name'    => 'Vatu',
+        'code'    => 'VUV',
         'number'  => '548'
     },
     'WST' => {
         'country' => ['SAMOA'],
         'name'    => 'Tala',
+        'code'    => 'WST',
         'number'  => '882'
     },
     'XAF' => {
@@ -932,6 +1089,7 @@ my %currencies = (
             'GABON'
         ],
         'name'    => 'CFA Franc BEAC',
+        'code'    => 'XAF',
         'number'  => '950'
     },
     'XCD' => {
@@ -946,11 +1104,13 @@ my %currencies = (
             'SAINT VINCENT AND THE GRENADINES'
         ],
         'name'    => 'East Caribbean Dollar',
+        'code'    => 'XCD',
         'number'  => '951'
     },
     'XDR' => {
         'country' => ['INTERNATIONAL MONETARY FUND (IMF) '],
         'name'    => 'SDR (Special Drawing Right)',
+        'code'    => 'XDR',
         'number'  => '960'
     },
     'XOF' => {
@@ -965,6 +1125,7 @@ my %currencies = (
             'TOGO'
         ],
         'name'    => 'CFA Franc BCEAO',
+        'code'    => 'XOF',
         'number'  => '952'
     },
     'XPF' => {
@@ -974,21 +1135,25 @@ my %currencies = (
             'WALLIS AND FUTUNA'
         ],
         'name'    => 'CFP Franc',
+        'code'    => 'XPF',
         'number'  => '953'
     },
     'XSU' => {
         'country' => ['SISTEMA UNITARIO DE COMPENSACION REGIONAL DE PAGOS "SUCRE"'],
         'name'    => 'Sucre',
+        'code'    => 'XSU',
         'number'  => '994'
     },
     'XUA' => {
         'country' => ['MEMBER COUNTRIES OF THE AFRICAN DEVELOPMENT BANK GROUP'],
         'name'    => 'ADB Unit of Account',
+        'code'    => 'XUA',
         'number'  => '965'
     },
     'YER' => {
         'country' => ['YEMEN'],
         'name'    => 'Yemeni Rial',
+        'code'    => 'YER',
         'number'  => '886'
     },
     'ZAR' => {
@@ -998,16 +1163,19 @@ my %currencies = (
             'SOUTH AFRICA'
         ],
         'name'    => 'Rand',
+        'code'    => 'ZAR',
         'number'  => '710'
     },
     'ZMW' => {
         'country' => ['ZAMBIA'],
         'name'    => 'Zambian Kwacha',
+        'code'    => 'ZMW',
         'number'  => '967'
     },
     'ZWL' => {
         'country' => ['ZIMBABWE'],
         'name'    => 'Zimbabwe Dollar',
+        'code'    => 'ZWL',
         'number'  => '932'
     },
 
@@ -1052,6 +1220,7 @@ sub fetch_live_currencies {
     else {
       $result{$code} = {'name'    => $currency,
                         'country' => [$country],
+                        'code'    => $code,
                         'number'  => $number};
     }
   }
@@ -1096,8 +1265,8 @@ Both functions return a hash
 
 =head1 CACHE DATE
 
-The currency list stored in this module was last copied from the live site July
-2019.
+The currency list stored in this module was last copied from the live site Oct
+2020.
 
 =head1 LICENSE
 

--- a/lib/Finance/Quote/Tiaacref.pm
+++ b/lib/Finance/Quote/Tiaacref.pm
@@ -29,272 +29,136 @@
 
 package Finance::Quote::Tiaacref;
 require 5.005;
-require LWP::Protocol::https;
-require Mozilla::CA;
 
 use strict;
 
-use vars qw( $CREF_URL $TIAA_URL
-			%tiaacref_ids %tiaacref_locs %tiaacref_vals);
-
-use LWP::UserAgent;
-use HTTP::Request::Common;
-use Carp;
-use Encode;
+use Encode qw/decode/;
+use Time::Piece;
+use Time::Seconds;
+use Try::Tiny;
 
 # VERSION
 
 # URLs of where to obtain information.
-# This used to be different for the CREF and TIAA annuities, but this changed.
-$CREF_URL = ("https://www.tiaa-cref.org/public/tcfpi/Export/InvestmentDetails?Details=DailyPerformance");
+my $TIAA_MAIN_URL = 'https://www.tiaa.org/public/investment-performance';
+my $TIAA_DATA_URL = 'https://www.tiaa.markitondemand.com/Research/Public/Export/Details';
 
 sub methods { return (tiaacref=>\&tiaacref); }
 
-sub labels { return (tiaacref => [qw/method symbol exchange name date isodate nav price/]); }
+sub labels { return (tiaacref => [qw/
+    method
+    symbol
+    exchange
+    name
+    date
+    isodate
+    nav
+    price
+    currency
+/]); }
 
 # =======================================================================
 # TIAA-CREF Annuities are not listed on any exchange, unlike their mutual funds
 # TIAA-CREF provides unit values via a cgi on their website. The cgi returns
 # a csv file in the format
-#		bogus_symbol1,price1,date1
-#		bogus_symbol2,price2,date2
+#   description,price1,date1
+#   description,price2,date2
 #       ..etc.
-# where bogus_symbol takes on the following values for the various annuities:
-#
-# CREF Bond Market Account (R1):	CREFbond (QCBMRX)	41081991
-# CREF Bond Market Account (R2):	QCBMPX	268585732
-# CREF Bond Market Account (R3):	QCBMIX	268581927
-# CREF Equity Index Account (R1):	CREFequi (QCEQRX)	41082540
-# CREF Equity Index Account (R2):	QCEQPX	268568309
-# CREF Equity Index Account (R3):	QCEQIX	268561119
-# CREF Global Equities Account (R1):	CREFglob (QCGLRX)	41081992
-# CREF Global Equities Account (R2):	QCGLPX	268563498
-# CREF Global Equities Account (R3):	QCGLIX	268551676
-# CREF Growth Account (R1):	CREFgrow (QCGRRX)	41082544
-# CREF Growth Account (R2):	QCGRPX	268527829
-# CREF Growth Account (R3):	QCGRIX	268576313
-# CREF Inflation-Linked Bond Account (R1):	CREFinfb (QCILRX)	41088773
-# CREF Inflation-Linked Bond Account (R2):	QCILPX	268587933
-# CREF Inflation-Linked Bond Account (R3):	QCILIX	268572721
-# CREF Money Market Account (R1):	CREFmony (QCMMRX)	41081993
-# CREF Money Market Account (R2):	QCMMPX	268532453
-# CREF Money Market Account (R3):	QCMMIX	268569116
-# CREF Social Choice Account (R1):	CREFsoci (QCSCRX)	41081994
-# CREF Social Choice Account (R2):	QCSCPX	268580724
-# CREF Social Choice Account (R3):	QCSCIX	268585136
-# CREF Stock Account (R1):	CREFstok (QCSTRX)	41081995
-# CREF Stock Account (R2):	QCSTPX	268540687
-# CREF Stock Account (R3):	QCSTIX	268555492
-# TIAA Real Estate Account:	TIAAreal (QREARX)	41091375
-# TIAA-CREF Bond Fund (Retirement):	TIDRX	4530828
-# TIAA-CREF Bond Index Fund (Retirement):	TBIRX	20739662
-# TIAA-CREF Bond Plus Fund (Retirement):	TCBRX	4530816
-# TIAA-CREF Emerging Markets Debt Fund (Retirement):	TEDTX	78873869
-# TIAA-CREF Emerging Markets Equity Fund (Retirement):	TEMSX	26176543
-# TIAA-CREF Emerging Markets Equity Index Fund (Retirement):	TEQSX	26176547
-# TIAA-CREF Equity Index Fund (Retirement):	TIQRX	4530786
-# TIAA-CREF Global Natural Resources Fund (Retirement):	TNRRX	39444919
-# TIAA-CREF Growth & Income Fund (Retirement):	TRGIX	312536
-# TIAA-CREF High Yield Fund (Retirement):	TIHRX	4530821
-# TIAA-CREF Inflation-Linked Bond Fund (Retirement):	TIKRX	4530829
-# TIAA-CREF International Equity Fund (Retirement):	TRERX	302323
-# TIAA-CREF International Equity Index Fund (Retirement):	TRIEX	300269
-# TIAA-CREF International Opportunities Fund (Retirement):	TIOTX	57085015
-# TIAA-CREF Large-Cap Growth Fund (Retirement):	TILRX	4530785
-# TIAA-CREF Large-Cap Growth Index Fund (Retirement):	TRIRX	299525
-# TIAA-CREF Large-Cap Value Fund (Retirement):	TRLCX	301332
-# TIAA-CREF Large-Cap Value Index Fund (Retirement):	TRCVX	304333
-# TIAA-CREF Lifecycle 2010 Fund (Retirement):	TCLEX	302817
-# TIAA-CREF Lifecycle 2015 Fund (Retirement):	TCLIX	302393
-# TIAA-CREF Lifecycle 2020 Fund (Retirement):	TCLTX	307774
-# TIAA-CREF Lifecycle 2025 Fund (Retirement):	TCLFX	313994
-# TIAA-CREF Lifecycle 2030 Fund (Retirement):	TCLNX	307240
-# TIAA-CREF Lifecycle 2035 Fund (Retirement):	TCLRX	309003
-# TIAA-CREF Lifecycle 2040 Fund (Retirement):	TCLOX	300959
-# TIAA-CREF Lifecycle 2045 Fund (Retirement):	TTFRX	9467597
-# TIAA-CREF Lifecycle 2050 Fund (Retirement):	TLFRX	9467596
-# TIAA-CREF Lifecycle 2055 Fund (Retirement):	TTRLX	34211330
-# TIAA-CREF Lifecycle 2060 Fund (Retirement):	TLXRX	78873871
-# TIAA-CREF Lifecycle Index 2010 Fund (Retirement):	TLTRX	21066482
-# TIAA-CREF Lifecycle Index 2015 Fund (Retirement):	TLGRX	21066496
-# TIAA-CREF Lifecycle Index 2020 Fund (Retirement):	TLWRX	21066479
-# TIAA-CREF Lifecycle Index 2025 Fund (Retirement):	TLQRX	21066485
-# TIAA-CREF Lifecycle Index 2030 Fund (Retirement):	TLHRX	21066435
-# TIAA-CREF Lifecycle Index 2035 Fund (Retirement):	TLYRX	21066475
-# TIAA-CREF Lifecycle Index 2040 Fund (Retirement):	TLZRX	21066473
-# TIAA-CREF Lifecycle Index 2045 Fund (Retirement):	TLMRX	21066488
-# TIAA-CREF Lifecycle Index 2050 Fund (Retirement):	TLLRX	21066490
-# TIAA-CREF Lifecycle Index 2055 Fund (Retirement):	TTIRX	34211328
-# TIAA-CREF Lifecycle Index 2060 Fund (Retirement):	TVITX	78873875
-# TIAA-CREF Lifecycle Index Retirement Income Fund (Retirement):	TRCIX	21066468
-# TIAA-CREF Lifecycle Retirement Income Fund (Retirement):	TLIRX	9467594
-# TIAA-CREF Lifestyle Aggressive Growth Fund (Retirement):	TSARX	40508431
-# TIAA-CREF Lifestyle Conservative Fund (Retirement):	TSCTX	40508433
-# TIAA-CREF Lifestyle Growth Fund (Retirement):	TSGRX	40508437
-# TIAA-CREF Lifestyle Income Fund (Retirement):	TLSRX	40508427
-# TIAA-CREF Lifestyle Moderate Fund (Retirement):	TSMTX	40508460
-# TIAA-CREF Managed Allocation Fund (Retirement):	TITRX	4530825
-# TIAA-CREF Mid-Cap Growth Fund (Retirement):	TRGMX	305499
-# TIAA-CREF Mid-Cap Value Fund (Retirement):	TRVRX	315272
-# TIAA-CREF Money Market Fund (Retirement):	TIEXX	4530771
-# TIAA-CREF Real Estate Securities Fund (Retirement):	TRRSX	300081
-# TIAA-CREF S&P 500 Index Fund (Retirement):	TRSPX	306105
-# TIAA-CREF Short-Term Bond Fund (Retirement):	TISRX	4530818
-# TIAA-CREF Small-Cap Blend Index Fund (Retirement):	TRBIX	314644
-# TIAA-CREF Small-Cap Equity Fund (Retirement):	TRSEX	299968
-# TIAA-CREF Social Choice Bond Fund (Retirement):	TSBBX	49604881
-# TIAA-CREF Social Choice Equity Fund (Retirement):	TRSCX	300078
-# TIAA-CREF Bond Fund (Institutional):	TIBDX	307276
-# TIAA-CREF Bond Index Fund (Institutional):	TBIIX	20739664
-# TIAA-CREF Bond Plus Fund (Institutional):	TIBFX	4530820
-# TIAA-CREF Emerging Markets Debt Fund (Institutional):	TEDNX	78873868
-# TIAA-CREF Emerging Markets Equity Fund (Institutional):	TEMLX	26176540
-# TIAA-CREF Emerging Markets Equity Index Fund (Institutional):	TEQLX	26176544
-# TIAA-CREF Enhanced International Equity Index Fund (Institutional):	TFIIX	9467603
-# TIAA-CREF Enhanced Large-Cap Growth Index Fund (Institutional):	TLIIX	9467602
-# TIAA-CREF Enhanced Large-Cap Value Index Fund (Institutional):	TEVIX	9467606
-# TIAA-CREF Equity Index Fund (Institutional):	TIEIX	301718
-# TIAA-CREF Global Natural Resources Fund (Institutional):	TNRIX	39444916
-# TIAA-CREF Growth & Income Fund (Institutional):	TIGRX	314719
-# TIAA-CREF High Yield Fund (Institutional):	TIHYX	4530798
-# TIAA-CREF Inflation-Linked Bond Fund (Institutional):	TIILX	316693
-# TIAA-CREF International Equity Fund (Institutional):	TIIEX	305980
-# TIAA-CREF International Equity Index Fund (Institutional):	TCIEX	303673
-# TIAA-CREF International Opportunities Fund (Institutional):	TIOIX	57085012
-# TIAA-CREF Large-Cap Growth Fund (Institutional):	TILGX	4530800
-# TIAA-CREF Large-Cap Growth Index Fund (Institutional):	TILIX	297809
-# TIAA-CREF Large-Cap Value Fund (Institutional):	TRLIX	300692
-# TIAA-CREF Large-Cap Value Index Fund (Institutional):	TILVX	302308
-# TIAA-CREF Lifecycle 2010 Fund (Institutional):	TCTIX	4912376
-# TIAA-CREF Lifecycle 2015 Fund (Institutional):	TCNIX	4912355
-# TIAA-CREF Lifecycle 2020 Fund (Institutional):	TCWIX	4912377
-# TIAA-CREF Lifecycle 2025 Fund (Institutional):	TCYIX	4912384
-# TIAA-CREF Lifecycle 2030 Fund (Institutional):	TCRIX	4912364
-# TIAA-CREF Lifecycle 2035 Fund (Institutional):	TCIIX	4912375
-# TIAA-CREF Lifecycle 2040 Fund (Institutional):	TCOIX	4912387
-# TIAA-CREF Lifecycle 2045 Fund (Institutional):	TTFIX	9467607
-# TIAA-CREF Lifecycle 2050 Fund (Institutional):	TFTIX	9467601
-# TIAA-CREF Lifecycle 2055 Fund (Institutional):	TTRIX	34211329
-# TIAA-CREF Lifecycle 2060 Fund (Institutional):	TLXNX	78873872
-# TIAA-CREF Lifecycle Index 2010 Fund (Institutional):	TLTIX	21066484
-# TIAA-CREF Lifecycle Index 2015 Fund (Institutional):	TLFIX	21066498
-# TIAA-CREF Lifecycle Index 2020 Fund (Institutional):	TLWIX	21066480
-# TIAA-CREF Lifecycle Index 2025 Fund (Institutional):	TLQIX	21066486
-# TIAA-CREF Lifecycle Index 2030 Fund (Institutional):	TLHIX	21066495
-# TIAA-CREF Lifecycle Index 2035 Fund (Institutional):	TLYIX	21066477
-# TIAA-CREF Lifecycle Index 2040 Fund (Institutional):	TLZIX	21066474
-# TIAA-CREF Lifecycle Index 2045 Fund (Institutional):	TLXIX	21066478
-# TIAA-CREF Lifecycle Index 2050 Fund (Institutional):	TLLIX	21066492
-# TIAA-CREF Lifecycle Index 2055 Fund (Institutional):	TTIIX	34211326
-# TIAA-CREF Lifecycle Index 2060 Fund (Institutional):	TVIIX	78873873
-# TIAA-CREF Lifecycle Index Retirement Income Fund (Institutional):	TRILX	21066463
-# TIAA-CREF Lifecycle Retirement Income Fund (Institutional):	TLRIX	9467595
-# TIAA-CREF Lifestyle Aggressive Growth Fund (Institutional):	TSAIX	40508428
-# TIAA-CREF Lifestyle Conservative Fund (Institutional):	TCSIX	40508425
-# TIAA-CREF Lifestyle Growth Fund (Institutional):	TSGGX	40508434
-# TIAA-CREF Lifestyle Income Fund (Institutional):	TSITX	40508450
-# TIAA-CREF Lifestyle Moderate Fund (Institutional):	TSIMX	40508443
-# TIAA-CREF Managed Allocation Fund (Institutional):	TIMIX	4530787
-# TIAA-CREF Mid-Cap Growth Fund (Institutional):	TRPWX	297210
-# TIAA-CREF Mid-Cap Value Fund (Institutional):	TIMVX	316178
-# TIAA-CREF Money Market Fund (Institutional):	TCIXX	313650
-# TIAA-CREF Real Estate Securities Fund (Institutional):	TIREX	303475
-# TIAA-CREF S&P 500 Index Fund (Institutional):	TISPX	306658
-# TIAA-CREF Short-Term Bond Fund (Institutional):	TISIX	4530784
-# TIAA-CREF Small-Cap Blend Index Fund (Institutional):	TISBX	309018
-# TIAA-CREF Small-Cap Equity Fund (Institutional):	TISEX	301622
-# TIAA-CREF Social Choice Bond Fund (Institutional):	TSBIX	49604882
-# TIAA-CREF Social Choice Equity Fund (Institutional):	TISCX	301897
-# TIAA-CREF Tax-Exempt Bond Fund (Institutional):	TITIX	4530819
-# TIAA-CREF Bond Fund (Retail):	TIORX	4530794
-# TIAA-CREF Bond Index Fund (Retail):	TBILX	20739663
-# TIAA-CREF Bond Plus Fund (Retail):	TCBPX	4530788
-# TIAA-CREF Emerging Markets Debt Fund (Retail):	TEDLX	78873866
-# TIAA-CREF Emerging Markets Equity Fund (Retail):	TEMRX	26176542
-# TIAA-CREF Emerging Markets Equity Index Fund (Retail):	TEQKX	26176545
-# TIAA-CREF Equity Index Fund (Retail):	TINRX	4530797
-# TIAA-CREF Global Natural Resources Fund (Retail):	TNRLX	39444917
-# TIAA-CREF Growth & Income Fund (Retail):	TIIRX	4530790
-# TIAA-CREF High Yield Fund (Retail):	TIYRX	4530830
-# TIAA-CREF Inflation-Linked Bond Fund (Retail):	TCILX	313727
-# TIAA-CREF International Equity Fund (Retail):	TIERX	4530827
-# TIAA-CREF International Opportunities Fund (Retail):	TIOSX	57085014
-# TIAA-CREF Large-Cap Growth Fund (Retail):	TIRTX	4530791
-# TIAA-CREF Large-Cap Value Fund (Retail):	TCLCX	302696
-# TIAA-CREF Lifecycle Retirement Income Fund (Retail):	TLRRX	9467600
-# TIAA-CREF Lifestyle Aggressive Growth Fund (Retail):	TSALX	40508429
-# TIAA-CREF Lifestyle Conservative Fund (Retail):	TSCLX	40508432
-# TIAA-CREF Lifestyle Growth Fund (Retail):	TSGLX	40508435
-# TIAA-CREF Lifestyle Income Fund (Retail):	TSILX	40508438
-# TIAA-CREF Lifestyle Moderate Fund (Retail):	TSMLX	40508453
-# TIAA-CREF Managed Allocation Fund (Retail):	TIMRX	4530817
-# TIAA-CREF Mid-Cap Growth Fund (Retail):	TCMGX	305208
-# TIAA-CREF Mid-Cap Value Fund (Retail):	TCMVX	313995
-# TIAA-CREF Money Market Fund (Retail):	TIRXX	4530775
-# TIAA-CREF Real Estate Securities Fund (Retail):	TCREX	309567
-# TIAA-CREF Short-Term Bond Fund (Retail):	TCTRX	4530822
-# TIAA-CREF Small-Cap Equity Fund (Retail):	TCSEX	297477
-# TIAA-CREF Social Choice Bond Fund (Retail):	TSBRX	49604884
-# TIAA-CREF Social Choice Equity Fund (Retail):	TICRX	4530792
-# TIAA-CREF Tax-Exempt Bond Fund (Retail):	TIXRX	4530793
-# TIAA-CREF Bond Fund (Premier):	TIDPX	21066506
-# TIAA-CREF Bond Index Fund (Premier):	TBIPX	21066534
-# TIAA-CREF Bond Plus Fund (Premier):	TBPPX	21066533
-# TIAA-CREF Emerging Markets Debt Fund (Premier):	TEDPX	78873867
-# TIAA-CREF Emerging Markets Equity Fund (Premier):	TEMPX	26176541
-# TIAA-CREF Emerging Markets Equity Index Fund (Premier):	TEQPX	26176546
-# TIAA-CREF Equity Index Fund (Premier):	TCEPX	21066530
-# TIAA-CREF Global Natural Resources Fund (Premier):	TNRPX	39444918
-# TIAA-CREF Growth & Income Fund (Premier):	TRPGX	21066461
-# TIAA-CREF High Yield Fund (Premier):	TIHPX	21066501
-# TIAA-CREF Inflation-Linked Bond Fund (Premier):	TIKPX	21066500
-# TIAA-CREF International Equity Fund (Premier):	TREPX	21066466
-# TIAA-CREF International Equity Index Fund (Premier):	TRIPX	21066462
-# TIAA-CREF International Opportunities Fund (Premier):	TIOPX	57085013
-# TIAA-CREF Large-Cap Growth Fund (Premier):	TILPX	21066499
-# TIAA-CREF Large-Cap Value Fund (Premier):	TRCPX	21066467
-# TIAA-CREF Lifecycle 2010 Fund (Premier):	TCTPX	21066521
-# TIAA-CREF Lifecycle 2015 Fund (Premier):	TCFPX	21066528
-# TIAA-CREF Lifecycle 2020 Fund (Premier):	TCWPX	21066518
-# TIAA-CREF Lifecycle 2025 Fund (Premier):	TCQPX	21066522
-# TIAA-CREF Lifecycle 2030 Fund (Premier):	TCHPX	21066527
-# TIAA-CREF Lifecycle 2035 Fund (Premier):	TCYPX	21066517
-# TIAA-CREF Lifecycle 2040 Fund (Premier):	TCZPX	21066516
-# TIAA-CREF Lifecycle 2045 Fund (Premier):	TTFPX	21066444
-# TIAA-CREF Lifecycle 2050 Fund (Premier):	TCLPX	21066526
-# TIAA-CREF Lifecycle 2055 Fund (Premier):	TTRPX	34211331
-# TIAA-CREF Lifecycle 2060 Fund (Premier):	TLXPX	78873870
-# TIAA-CREF Lifecycle Index 2010 Fund (Premier):	TLTPX	21066483
-# TIAA-CREF Lifecycle Index 2015 Fund (Premier):	TLFPX	21066497
-# TIAA-CREF Lifecycle Index 2020 Fund (Premier):	TLWPX	21066434
-# TIAA-CREF Lifecycle Index 2025 Fund (Premier):	TLVPX	21066481
-# TIAA-CREF Lifecycle Index 2030 Fund (Premier):	TLHPX	21066494
-# TIAA-CREF Lifecycle Index 2035 Fund (Premier):	TLYPX	21066476
-# TIAA-CREF Lifecycle Index 2040 Fund (Premier):	TLPRX	21066487
-# TIAA-CREF Lifecycle Index 2045 Fund (Premier):	TLMPX	21066489
-# TIAA-CREF Lifecycle Index 2050 Fund (Premier):	TLLPX	21066491
-# TIAA-CREF Lifecycle Index 2055 Fund (Premier):	TTIPX	34211327
-# TIAA-CREF Lifecycle Index 2060 Fund (Premier):	TVIPX	78873874
-# TIAA-CREF Lifecycle Index Retirement Income Fund (Premier):	TLIPX	21066493
-# TIAA-CREF Lifecycle Retirement Income Fund (Premier):	TPILX	21066470
-# TIAA-CREF Lifestyle Aggressive Growth Fund (Premier):	TSAPX	40508430
-# TIAA-CREF Lifestyle Conservative Fund (Premier):	TLSPX	40508426
-# TIAA-CREF Lifestyle Growth Fund (Premier):	TSGPX	40508436
-# TIAA-CREF Lifestyle Income Fund (Premier):	TSIPX	40508451
-# TIAA-CREF Lifestyle Moderate Fund (Premier):	TSMPX	40508456
-# TIAA-CREF Mid-Cap Growth Fund (Premier):	TRGPX	21066464
-# TIAA-CREF Mid-Cap Value Fund (Premier):	TRVPX	21066455
-# TIAA-CREF Money Market Fund (Premier):	TPPXX	21066469
-# TIAA-CREF Real Estate Securities Fund (Premier):	TRRPX	21066459
-# TIAA-CREF Short-Term Bond Fund (Premier):	TSTPX	21066445
-# TIAA-CREF Small-Cap Equity Fund (Premier):	TSRPX	21066446
-# TIAA-CREF Social Choice Bond Fund (Premier):	TSBPX	49604883
-# TIAA-CREF Social Choice Equity Fund (Premier):	TRPSX	21066460
 
+# As of 11-Oct-2020, the following securities are found in their lookup
+# service. Data for some of these are available elsewhere and some are not:
+
+# QCBMIX  QCBMPX  QCBMRX  QCEQIX  QCEQPX  QCEQRX  QCGLIX  QCGLPX  QCGLRX  
+# QCGRIX  QCGRPX  QCGRRX  QCILIX  QCILPX  QCILRX  QCMMIX  QCMMPX  QCMMRX  
+# QCSCIX  QCSCPX  QCSCRX  QCSTIX  QCSTPX  QCSTRX  QREARX  TAISX   TAIWX   
+# TBBWX   TBIAX   TBIIX   TBILX   TBIPX   TBIRX   TBIWX   TBPPX   TCBHX   
+# TCBPX   TCBRX   TCBWX   TCCHX   TCEPX   TCFPX   TCHHX   TCHPX   TCIEX   
+# TCIHX   TCIIX   TCILX   TCIWX   TCIXX   TCLCX   TCLEX   TCLFX   TCLHX   
+# TCLIX   TCLNX   TCLOX   TCLPX   TCLRX   TCLTX   TCMGX   TCMHX   TCMVX   
+# TCNHX   TCNIX   TCOIX   TCQHX   TCQPX   TCREX   TCRIX   TCSEX   TCSIX   
+# TCTHX   TCTIX   TCTPX   TCTRX   TCTWX   TCWHX   TCWIX   TCWPX   TCYHX   
+# TCYIX   TCYPX   TCZHX   TCZPX   TECGX   TECWX   TEDHX   TEDLX   TEDNX   
+# TEDPX   TEDTX   TEDVX   TEIEX   TEIHX   TEIWX   TELCX   TELWX   TEMHX   
+# TEMLX   TEMPX   TEMRX   TEMSX   TEMVX   TENWX   TEQHX   TEQKX   TEQLX   
+# TEQPX   TEQSX   TEQWX   TESHX   TEVIX   TEWCX   TFIHX   TFIIX   TFIPX   
+# TFIRX   TFITX   TFTHX   TFTIX   TGIHX   TGIWX   TGRKX   TGRLX   TGRMX   
+# TGRNX   TGROX   THCVX   THCWX   TIBDX   TIBEX   TIBFX   TIBHX   TIBLX   
+# TIBNX   TIBUX   TIBVX   TIBWX   TICHX   TICRX   TIDPX   TIDRX   TIEHX   
+# TIEIX   TIERX   TIEWX   TIEXX   TIGRX   TIHHX   TIHPX   TIHRX   TIHWX   
+# TIHYX   TIIEX   TIIHX   TIILX   TIIRX   TIISX   TIIWX   TIKPX   TIKRX   
+# TILGX   TILHX   TILIX   TILPX   TILRX   TILVX   TILWX   TIMIX   TIMRX   
+# TIMVX   TINRX   TIOHX   TIOIX   TIOPX   TIORX   TIOSX   TIOTX   TIOVX   
+# TIQRX   TIREX   TIRHX   TIRTX   TIRXX   TISAX   TISBX   TISCX   TISEX   
+# TISIX   TISPX   TISRX   TISWX   TITIX   TITRX   TIXHX   TIXRX   TIYRX   
+# TLFAX   TLFIX   TLFPX   TLFRX   TLGRX   TLHHX   TLHIX   TLHPX   TLHRX   
+# TLIHX   TLIIX   TLIPX   TLIRX   TLISX   TLLHX   TLLIX   TLLPX   TLLRX   
+# TLMHX   TLMPX   TLMRX   TLPRX   TLQHX   TLQIX   TLQRX   TLRHX   TLRIX   
+# TLRRX   TLSHX   TLSPX   TLSRX   TLTHX   TLTIX   TLTPX   TLTRX   TLVPX   
+# TLWCX   TLWHX   TLWIX   TLWPX   TLWRX   TLXHX   TLXIX   TLXNX   TLXPX   
+# TLXRX   TLYHX   TLYIX   TLYPX   TLYRX   TLZHX   TLZIX   TLZRX   TMHXX   
+# TNSHX   TNWCX   TPILX   TPISX   TPPXX   TPSHX   TPWCX   TRBIX   TRCIX   
+# TRCPX   TRCVX   TREPX   TRERX   TRGIX   TRGMX   TRGPX   TRHBX   TRIEX   
+# TRIHX   TRILX   TRIPX   TRIRX   TRIWX   TRLCX   TRLHX   TRLIX   TRLWX   
+# TRPGX   TRPSX   TRPWX   TRRPX   TRRSX   TRSCX   TRSEX   TRSHX   TRSPX   
+# TRVHX   TRVPX   TRVRX   TSAHX   TSAIX   TSALX   TSAPX   TSARX   TSBBX   
+# TSBHX   TSBIX   TSBPX   TSBRX   TSCHX   TSCLX   TSCTX   TSCWX   TSDBX   
+# TSDDX   TSDFX   TSDHX   TSDJX   TSFHX   TSFPX   TSFRX   TSFTX   TSGGX   
+# TSGHX   TSGLX   TSGPX   TSGRX   TSIHX   TSILX   TSIMX   TSIPX   TSITX   
+# TSMEX   TSMHX   TSMLX   TSMMX   TSMNX   TSMOX   TSMPX   TSMTX   TSMUX   
+# TSMWX   TSOEX   TSOHX   TSONX   TSOPX   TSORX   TSRPX   TSTPX   TTBHX   
+# TTBWX   TTFHX   TTFIX   TTFPX   TTFRX   TTIHX   TTIIX   TTIPX   TTIRX   
+# TTISX   TTRHX   TTRIX   TTRLX   TTRPX   TVIHX   TVIIX   TVIPX   TVITX   
+# W111#   W113#   W114#   W115#   W116#   W117#   W118#   W119#   W120#   
+# W121#   W122#   W123#   W128#   W130#   W131#   W132#   W133#   W134#   
+# W135#   W136#   W137#   W138#   W139#   W140#   W141#   W142#   W143#   
+# W144#   W145#   W146#   W147#   W148#   W149#   W150#   W151#   W152#   
+# W153#   W154#   W155#   W156#   W157#   W158#   W159#   W160#   W161#   
+# W162#   W163#   W164#   W165#   W166#   W167#   W168#   W169#   W170#   
+# W171#   W172#   W173#   W174#   W175#   W176#   W177#   W178#   W179#   
+# W180#   W211#   W213#   W214#   W215#   W216#   W217#   W218#   W219#   
+# W220#   W221#   W222#   W223#   W228#   W230#   W231#   W232#   W233#   
+# W234#   W235#   W236#   W237#   W238#   W239#   W240#   W241#   W242#   
+# W243#   W244#   W245#   W246#   W247#   W248#   W249#   W250#   W251#   
+# W252#   W253#   W254#   W255#   W256#   W257#   W258#   W259#   W260#   
+# W261#   W262#   W263#   W264#   W265#   W266#   W267#   W268#   W269#   
+# W270#   W271#   W272#   W273#   W274#   W275#   W276#   W277#   W278#   
+# W279#   W280#   W311#   W313#   W314#   W315#   W316#   W317#   W318#   
+# W319#   W320#   W321#   W322#   W323#   W328#   W330#   W331#   W332#   
+# W333#   W334#   W335#   W336#   W337#   W338#   W339#   W340#   W341#   
+# W342#   W343#   W344#   W345#   W346#   W347#   W348#   W349#   W350#   
+# W351#   W352#   W353#   W354#   W355#   W356#   W357#   W358#   W359#   
+# W360#   W361#   W362#   W363#   W364#   W365#   W366#   W367#   W368#   
+# W369#   W370#   W371#   W372#   W373#   W374#   W375#   W376#   W377#   
+# W378#   W379#   W380#   W411#   W413#   W414#   W415#   W416#   W417#   
+# W418#   W419#   W420#   W421#   W422#   W423#   W428#   W430#   W431#   
+# W432#   W433#   W434#   W435#   W436#   W437#   W438#   W439#   W440#   
+# W441#   W442#   W443#   W444#   W445#   W446#   W447#   W448#   W449#   
+# W450#   W451#   W452#   W453#   W454#   W455#   W456#   W457#   W458#   
+# W459#   W460#   W461#   W462#   W463#   W464#   W465#   W466#   W467#   
+# W468#   W469#   W470#   W471#   W472#   W473#   W474#   W475#   W476#   
+# W477#   W478#   W479#   W480#   W511#   W512#   W514#   W515#   W516#   
+# W517#   W518#   W519#   W520#   W521#   W522#   W523#   W524#   W525#   
+# W526#   W527#   W528#   W529#   W530#   W531#   W532#   W533#   W534#   
+# W535#   W536#   W537#   W538#   W539#   W540#   W541#   W543#   W544#   
+# W545#   W546#   W547#   W548#   W549#   W550#   W611#   W612#   W614#   
+# W615#   W616#   W617#   W618#   W619#   W620#   W621#   W622#   W623#   
+# W624#   W625#   W626#   W627#   W628#   W629#   W630#   W631#   W632#   
+# W633#   W634#   W635#   W636#   W637#   W638#   W639#   W640#   W641#   
+# W643#   W644#   W645#   W646#   W647#   W648#   W649#   W650#   W711#   
+# W712#   W714#   W715#   W716#   W717#   W718#   W719#   W720#   W721#   
+# W722#   W723#   W724#   W725#   W726#   W727#   W728#   W729#   W730#   
+# W731#   W732#   W733#   W734#   W735#   W736#   W737#   W738#   W739#   
+# W740#   W741#   W743#   W744#   W745#   W746#   W747#   W748#   W749#   
+# W750#   W811#   W812#   W814#   W815#   W816#   W817#   W818#   W819#   
+# W820#   W821#   W822#   W823#   W824#   W825#   W826#   W827#   W828#   
+# W829#   W830#   W831#   W832#   W833#   W834#   W835#   W836#   W837#   
+# W838#   W839#   W840#   W841#   W843#   W844#   W845#   W846#   W847#   
+# W848#   W849#   W850#   
 #
 # This subroutine was written by Brent Neal <brentn@users.sourceforge.net>
 # Modified to support new TIAA-CREF webpages by Kevin Foss <kfoss@maine.edu> and Brent Neal
 # Modified to support new 2012 TIAA-CREF webpages by Carl LaCombe <calcisme@gmail.com>
+# Modified to support new 2020 TIAA webpages by Jeremy Volkening 
 
 #
 # TODO:
@@ -304,836 +168,134 @@ sub labels { return (tiaacref => [qw/method symbol exchange name date isodate na
 # Currently, we only grab the most recent price data.
 #
 
-sub tiaacref
-{
-	my $quoter = shift;
-	if (! %tiaacref_ids ) { #build a name hash for the annuities (once only)
-		$tiaacref_ids{"CREFbond"} = "CREF Bond Market Account (R1)";
-		$tiaacref_ids{"QCBMPX"} = "CREF Bond Market Account (R2)";
-		$tiaacref_ids{"QCBMIX"} = "CREF Bond Market Account (R3)";
-		$tiaacref_ids{"CREFequi"} = "CREF Equity Index Account (R1)";
-		$tiaacref_ids{"QCEQPX"} = "CREF Equity Index Account (R2)";
-		$tiaacref_ids{"QCEQIX"} = "CREF Equity Index Account (R3)";
-		$tiaacref_ids{"CREFglob"} = "CREF Global Equities Account (R1)";
-		$tiaacref_ids{"QCGLPX"} = "CREF Global Equities Account (R2)";
-		$tiaacref_ids{"QCGLIX"} = "CREF Global Equities Account (R3)";
-		$tiaacref_ids{"CREFgrow"} = "CREF Growth Account (R1)";
-		$tiaacref_ids{"QCGRPX"} = "CREF Growth Account (R2)";
-		$tiaacref_ids{"QCGRIX"} = "CREF Growth Account (R3)";
-		$tiaacref_ids{"CREFinfb"} = "CREF Inflation-Linked Bond Account (R1)";
-		$tiaacref_ids{"QCILPX"} = "CREF Inflation-Linked Bond Account (R2)";
-		$tiaacref_ids{"QCILIX"} = "CREF Inflation-Linked Bond Account (R3)";
-		$tiaacref_ids{"CREFmony"} = "CREF Money Market Account (R1)";
-		$tiaacref_ids{"QCMMPX"} = "CREF Money Market Account (R2)";
-		$tiaacref_ids{"QCMMIX"} = "CREF Money Market Account (R3)";
-		$tiaacref_ids{"CREFsoci"} = "CREF Social Choice Account (R1)";
-		$tiaacref_ids{"QCSCPX"} = "CREF Social Choice Account (R2)";
-		$tiaacref_ids{"QCSCIX"} = "CREF Social Choice Account (R3)";
-		$tiaacref_ids{"CREFstok"} = "CREF Stock Account (R1)";
-		$tiaacref_ids{"QCSTPX"} = "CREF Stock Account (R2)";
-		$tiaacref_ids{"QCSTIX"} = "CREF Stock Account (R3)";
-		$tiaacref_ids{"TIAAreal"} = "TIAA Real Estate Account";
-		$tiaacref_ids{"TIDRX"} = "TIAA-CREF Bond Fund (Retirement)";
-		$tiaacref_ids{"TBIRX"} = "TIAA-CREF Bond Index Fund (Retirement)";
-		$tiaacref_ids{"TCBRX"} = "TIAA-CREF Bond Plus Fund (Retirement)";
-		$tiaacref_ids{"TEDTX"} = "TIAA-CREF Emerging Markets Debt Fund (Retirement)";
-		$tiaacref_ids{"TEMSX"} = "TIAA-CREF Emerging Markets Equity Fund (Retirement)";
-		$tiaacref_ids{"TEQSX"} = "TIAA-CREF Emerging Markets Equity Index Fund (Retirement)";
-		$tiaacref_ids{"TIQRX"} = "TIAA-CREF Equity Index Fund (Retirement)";
-		$tiaacref_ids{"TNRRX"} = "TIAA-CREF Global Natural Resources Fund (Retirement)";
-		$tiaacref_ids{"TRGIX"} = "TIAA-CREF Growth & Income Fund (Retirement)";
-		$tiaacref_ids{"TIHRX"} = "TIAA-CREF High Yield Fund (Retirement)";
-		$tiaacref_ids{"TIKRX"} = "TIAA-CREF Inflation-Linked Bond Fund (Retirement)";
-		$tiaacref_ids{"TRERX"} = "TIAA-CREF International Equity Fund (Retirement)";
-		$tiaacref_ids{"TRIEX"} = "TIAA-CREF International Equity Index Fund (Retirement)";
-		$tiaacref_ids{"TIOTX"} = "TIAA-CREF International Opportunities Fund (Retirement)";
-		$tiaacref_ids{"TILRX"} = "TIAA-CREF Large-Cap Growth Fund (Retirement)";
-		$tiaacref_ids{"TRIRX"} = "TIAA-CREF Large-Cap Growth Index Fund (Retirement)";
-		$tiaacref_ids{"TRLCX"} = "TIAA-CREF Large-Cap Value Fund (Retirement)";
-		$tiaacref_ids{"TRCVX"} = "TIAA-CREF Large-Cap Value Index Fund (Retirement)";
-		$tiaacref_ids{"TCLEX"} = "TIAA-CREF Lifecycle 2010 Fund (Retirement)";
-		$tiaacref_ids{"TCLIX"} = "TIAA-CREF Lifecycle 2015 Fund (Retirement)";
-		$tiaacref_ids{"TCLTX"} = "TIAA-CREF Lifecycle 2020 Fund (Retirement)";
-		$tiaacref_ids{"TCLFX"} = "TIAA-CREF Lifecycle 2025 Fund (Retirement)";
-		$tiaacref_ids{"TCLNX"} = "TIAA-CREF Lifecycle 2030 Fund (Retirement)";
-		$tiaacref_ids{"TCLRX"} = "TIAA-CREF Lifecycle 2035 Fund (Retirement)";
-		$tiaacref_ids{"TCLOX"} = "TIAA-CREF Lifecycle 2040 Fund (Retirement)";
-		$tiaacref_ids{"TTFRX"} = "TIAA-CREF Lifecycle 2045 Fund (Retirement)";
-		$tiaacref_ids{"TLFRX"} = "TIAA-CREF Lifecycle 2050 Fund (Retirement)";
-		$tiaacref_ids{"TTRLX"} = "TIAA-CREF Lifecycle 2055 Fund (Retirement)";
-		$tiaacref_ids{"TLXRX"} = "TIAA-CREF Lifecycle 2060 Fund (Retirement)";
-		$tiaacref_ids{"TLTRX"} = "TIAA-CREF Lifecycle Index 2010 Fund (Retirement)";
-		$tiaacref_ids{"TLGRX"} = "TIAA-CREF Lifecycle Index 2015 Fund (Retirement)";
-		$tiaacref_ids{"TLWRX"} = "TIAA-CREF Lifecycle Index 2020 Fund (Retirement)";
-		$tiaacref_ids{"TLQRX"} = "TIAA-CREF Lifecycle Index 2025 Fund (Retirement)";
-		$tiaacref_ids{"TLHRX"} = "TIAA-CREF Lifecycle Index 2030 Fund (Retirement)";
-		$tiaacref_ids{"TLYRX"} = "TIAA-CREF Lifecycle Index 2035 Fund (Retirement)";
-		$tiaacref_ids{"TLZRX"} = "TIAA-CREF Lifecycle Index 2040 Fund (Retirement)";
-		$tiaacref_ids{"TLMRX"} = "TIAA-CREF Lifecycle Index 2045 Fund (Retirement)";
-		$tiaacref_ids{"TLLRX"} = "TIAA-CREF Lifecycle Index 2050 Fund (Retirement)";
-		$tiaacref_ids{"TTIRX"} = "TIAA-CREF Lifecycle Index 2055 Fund (Retirement)";
-		$tiaacref_ids{"TVITX"} = "TIAA-CREF Lifecycle Index 2060 Fund (Retirement)";
-		$tiaacref_ids{"TRCIX"} = "TIAA-CREF Lifecycle Index Retirement Income Fund (Retirement)";
-		$tiaacref_ids{"TLIRX"} = "TIAA-CREF Lifecycle Retirement Income Fund (Retirement)";
-		$tiaacref_ids{"TSARX"} = "TIAA-CREF Lifestyle Aggressive Growth Fund (Retirement)";
-		$tiaacref_ids{"TSCTX"} = "TIAA-CREF Lifestyle Conservative Fund (Retirement)";
-		$tiaacref_ids{"TSGRX"} = "TIAA-CREF Lifestyle Growth Fund (Retirement)";
-		$tiaacref_ids{"TLSRX"} = "TIAA-CREF Lifestyle Income Fund (Retirement)";
-		$tiaacref_ids{"TSMTX"} = "TIAA-CREF Lifestyle Moderate Fund (Retirement)";
-		$tiaacref_ids{"TITRX"} = "TIAA-CREF Managed Allocation Fund (Retirement)";
-		$tiaacref_ids{"TRGMX"} = "TIAA-CREF Mid-Cap Growth Fund (Retirement)";
-		$tiaacref_ids{"TRVRX"} = "TIAA-CREF Mid-Cap Value Fund (Retirement)";
-		$tiaacref_ids{"TIEXX"} = "TIAA-CREF Money Market Fund (Retirement)";
-		$tiaacref_ids{"TRRSX"} = "TIAA-CREF Real Estate Securities Fund (Retirement)";
-		$tiaacref_ids{"TRSPX"} = "TIAA-CREF S&P 500 Index Fund (Retirement)";
-		$tiaacref_ids{"TISRX"} = "TIAA-CREF Short-Term Bond Fund (Retirement)";
-		$tiaacref_ids{"TRBIX"} = "TIAA-CREF Small-Cap Blend Index Fund (Retirement)";
-		$tiaacref_ids{"TRSEX"} = "TIAA-CREF Small-Cap Equity Fund (Retirement)";
-		$tiaacref_ids{"TSBBX"} = "TIAA-CREF Social Choice Bond Fund (Retirement)";
-		$tiaacref_ids{"TRSCX"} = "TIAA-CREF Social Choice Equity Fund (Retirement)";
-		$tiaacref_ids{"TIBDX"} = "TIAA-CREF Bond Fund (Institutional)";
-		$tiaacref_ids{"TBIIX"} = "TIAA-CREF Bond Index Fund (Institutional)";
-		$tiaacref_ids{"TIBFX"} = "TIAA-CREF Bond Plus Fund (Institutional)";
-		$tiaacref_ids{"TEDNX"} = "TIAA-CREF Emerging Markets Debt Fund (Institutional)";
-		$tiaacref_ids{"TEMLX"} = "TIAA-CREF Emerging Markets Equity Fund (Institutional)";
-		$tiaacref_ids{"TEQLX"} = "TIAA-CREF Emerging Markets Equity Index Fund (Institutional)";
-		$tiaacref_ids{"TFIIX"} = "TIAA-CREF Enhanced International Equity Index Fund (Institutional)";
-		$tiaacref_ids{"TLIIX"} = "TIAA-CREF Enhanced Large-Cap Growth Index Fund (Institutional)";
-		$tiaacref_ids{"TEVIX"} = "TIAA-CREF Enhanced Large-Cap Value Index Fund (Institutional)";
-		$tiaacref_ids{"TIEIX"} = "TIAA-CREF Equity Index Fund (Institutional)";
-		$tiaacref_ids{"TNRIX"} = "TIAA-CREF Global Natural Resources Fund (Institutional)";
-		$tiaacref_ids{"TIGRX"} = "TIAA-CREF Growth & Income Fund (Institutional)";
-		$tiaacref_ids{"TIHYX"} = "TIAA-CREF High Yield Fund (Institutional)";
-		$tiaacref_ids{"TIILX"} = "TIAA-CREF Inflation-Linked Bond Fund (Institutional)";
-		$tiaacref_ids{"TIIEX"} = "TIAA-CREF International Equity Fund (Institutional)";
-		$tiaacref_ids{"TCIEX"} = "TIAA-CREF International Equity Index Fund (Institutional)";
-		$tiaacref_ids{"TIOIX"} = "TIAA-CREF International Opportunities Fund (Institutional)";
-		$tiaacref_ids{"TILGX"} = "TIAA-CREF Large-Cap Growth Fund (Institutional)";
-		$tiaacref_ids{"TILIX"} = "TIAA-CREF Large-Cap Growth Index Fund (Institutional)";
-		$tiaacref_ids{"TRLIX"} = "TIAA-CREF Large-Cap Value Fund (Institutional)";
-		$tiaacref_ids{"TILVX"} = "TIAA-CREF Large-Cap Value Index Fund (Institutional)";
-		$tiaacref_ids{"TCTIX"} = "TIAA-CREF Lifecycle 2010 Fund (Institutional)";
-		$tiaacref_ids{"TCNIX"} = "TIAA-CREF Lifecycle 2015 Fund (Institutional)";
-		$tiaacref_ids{"TCWIX"} = "TIAA-CREF Lifecycle 2020 Fund (Institutional)";
-		$tiaacref_ids{"TCYIX"} = "TIAA-CREF Lifecycle 2025 Fund (Institutional)";
-		$tiaacref_ids{"TCRIX"} = "TIAA-CREF Lifecycle 2030 Fund (Institutional)";
-		$tiaacref_ids{"TCIIX"} = "TIAA-CREF Lifecycle 2035 Fund (Institutional)";
-		$tiaacref_ids{"TCOIX"} = "TIAA-CREF Lifecycle 2040 Fund (Institutional)";
-		$tiaacref_ids{"TTFIX"} = "TIAA-CREF Lifecycle 2045 Fund (Institutional)";
-		$tiaacref_ids{"TFTIX"} = "TIAA-CREF Lifecycle 2050 Fund (Institutional)";
-		$tiaacref_ids{"TTRIX"} = "TIAA-CREF Lifecycle 2055 Fund (Institutional)";
-		$tiaacref_ids{"TLXNX"} = "TIAA-CREF Lifecycle 2060 Fund (Institutional)";
-		$tiaacref_ids{"TLTIX"} = "TIAA-CREF Lifecycle Index 2010 Fund (Institutional)";
-		$tiaacref_ids{"TLFIX"} = "TIAA-CREF Lifecycle Index 2015 Fund (Institutional)";
-		$tiaacref_ids{"TLWIX"} = "TIAA-CREF Lifecycle Index 2020 Fund (Institutional)";
-		$tiaacref_ids{"TLQIX"} = "TIAA-CREF Lifecycle Index 2025 Fund (Institutional)";
-		$tiaacref_ids{"TLHIX"} = "TIAA-CREF Lifecycle Index 2030 Fund (Institutional)";
-		$tiaacref_ids{"TLYIX"} = "TIAA-CREF Lifecycle Index 2035 Fund (Institutional)";
-		$tiaacref_ids{"TLZIX"} = "TIAA-CREF Lifecycle Index 2040 Fund (Institutional)";
-		$tiaacref_ids{"TLXIX"} = "TIAA-CREF Lifecycle Index 2045 Fund (Institutional)";
-		$tiaacref_ids{"TLLIX"} = "TIAA-CREF Lifecycle Index 2050 Fund (Institutional)";
-		$tiaacref_ids{"TTIIX"} = "TIAA-CREF Lifecycle Index 2055 Fund (Institutional)";
-		$tiaacref_ids{"TVIIX"} = "TIAA-CREF Lifecycle Index 2060 Fund (Institutional)";
-		$tiaacref_ids{"TRILX"} = "TIAA-CREF Lifecycle Index Retirement Income Fund (Institutional)";
-		$tiaacref_ids{"TLRIX"} = "TIAA-CREF Lifecycle Retirement Income Fund (Institutional)";
-		$tiaacref_ids{"TSAIX"} = "TIAA-CREF Lifestyle Aggressive Growth Fund (Institutional)";
-		$tiaacref_ids{"TCSIX"} = "TIAA-CREF Lifestyle Conservative Fund (Institutional)";
-		$tiaacref_ids{"TSGGX"} = "TIAA-CREF Lifestyle Growth Fund (Institutional)";
-		$tiaacref_ids{"TSITX"} = "TIAA-CREF Lifestyle Income Fund (Institutional)";
-		$tiaacref_ids{"TSIMX"} = "TIAA-CREF Lifestyle Moderate Fund (Institutional)";
-		$tiaacref_ids{"TIMIX"} = "TIAA-CREF Managed Allocation Fund (Institutional)";
-		$tiaacref_ids{"TRPWX"} = "TIAA-CREF Mid-Cap Growth Fund (Institutional)";
-		$tiaacref_ids{"TIMVX"} = "TIAA-CREF Mid-Cap Value Fund (Institutional)";
-		$tiaacref_ids{"TCIXX"} = "TIAA-CREF Money Market Fund (Institutional)";
-		$tiaacref_ids{"TIREX"} = "TIAA-CREF Real Estate Securities Fund (Institutional)";
-		$tiaacref_ids{"TISPX"} = "TIAA-CREF S&P 500 Index Fund (Institutional)";
-		$tiaacref_ids{"TISIX"} = "TIAA-CREF Short-Term Bond Fund (Institutional)";
-		$tiaacref_ids{"TISBX"} = "TIAA-CREF Small-Cap Blend Index Fund (Institutional)";
-		$tiaacref_ids{"TISEX"} = "TIAA-CREF Small-Cap Equity Fund (Institutional)";
-		$tiaacref_ids{"TSBIX"} = "TIAA-CREF Social Choice Bond Fund (Institutional)";
-		$tiaacref_ids{"TISCX"} = "TIAA-CREF Social Choice Equity Fund (Institutional)";
-		$tiaacref_ids{"TITIX"} = "TIAA-CREF Tax-Exempt Bond Fund (Institutional)";
-		$tiaacref_ids{"TIORX"} = "TIAA-CREF Bond Fund (Retail)";
-		$tiaacref_ids{"TBILX"} = "TIAA-CREF Bond Index Fund (Retail)";
-		$tiaacref_ids{"TCBPX"} = "TIAA-CREF Bond Plus Fund (Retail)";
-		$tiaacref_ids{"TEDLX"} = "TIAA-CREF Emerging Markets Debt Fund (Retail)";
-		$tiaacref_ids{"TEMRX"} = "TIAA-CREF Emerging Markets Equity Fund (Retail)";
-		$tiaacref_ids{"TEQKX"} = "TIAA-CREF Emerging Markets Equity Index Fund (Retail)";
-		$tiaacref_ids{"TINRX"} = "TIAA-CREF Equity Index Fund (Retail)";
-		$tiaacref_ids{"TNRLX"} = "TIAA-CREF Global Natural Resources Fund (Retail)";
-		$tiaacref_ids{"TIIRX"} = "TIAA-CREF Growth & Income Fund (Retail)";
-		$tiaacref_ids{"TIYRX"} = "TIAA-CREF High Yield Fund (Retail)";
-		$tiaacref_ids{"TCILX"} = "TIAA-CREF Inflation-Linked Bond Fund (Retail)";
-		$tiaacref_ids{"TIERX"} = "TIAA-CREF International Equity Fund (Retail)";
-		$tiaacref_ids{"TIOSX"} = "TIAA-CREF International Opportunities Fund (Retail)";
-		$tiaacref_ids{"TIRTX"} = "TIAA-CREF Large-Cap Growth Fund (Retail)";
-		$tiaacref_ids{"TCLCX"} = "TIAA-CREF Large-Cap Value Fund (Retail)";
-		$tiaacref_ids{"TLRRX"} = "TIAA-CREF Lifecycle Retirement Income Fund (Retail)";
-		$tiaacref_ids{"TSALX"} = "TIAA-CREF Lifestyle Aggressive Growth Fund (Retail)";
-		$tiaacref_ids{"TSCLX"} = "TIAA-CREF Lifestyle Conservative Fund (Retail)";
-		$tiaacref_ids{"TSGLX"} = "TIAA-CREF Lifestyle Growth Fund (Retail)";
-		$tiaacref_ids{"TSILX"} = "TIAA-CREF Lifestyle Income Fund (Retail)";
-		$tiaacref_ids{"TSMLX"} = "TIAA-CREF Lifestyle Moderate Fund (Retail)";
-		$tiaacref_ids{"TIMRX"} = "TIAA-CREF Managed Allocation Fund (Retail)";
-		$tiaacref_ids{"TCMGX"} = "TIAA-CREF Mid-Cap Growth Fund (Retail)";
-		$tiaacref_ids{"TCMVX"} = "TIAA-CREF Mid-Cap Value Fund (Retail)";
-		$tiaacref_ids{"TIRXX"} = "TIAA-CREF Money Market Fund (Retail)";
-		$tiaacref_ids{"TCREX"} = "TIAA-CREF Real Estate Securities Fund (Retail)";
-		$tiaacref_ids{"TCTRX"} = "TIAA-CREF Short-Term Bond Fund (Retail)";
-		$tiaacref_ids{"TCSEX"} = "TIAA-CREF Small-Cap Equity Fund (Retail)";
-		$tiaacref_ids{"TSBRX"} = "TIAA-CREF Social Choice Bond Fund (Retail)";
-		$tiaacref_ids{"TICRX"} = "TIAA-CREF Social Choice Equity Fund (Retail)";
-		$tiaacref_ids{"TIXRX"} = "TIAA-CREF Tax-Exempt Bond Fund (Retail)";
-		$tiaacref_ids{"TIDPX"} = "TIAA-CREF Bond Fund (Premier)";
-		$tiaacref_ids{"TBIPX"} = "TIAA-CREF Bond Index Fund (Premier)";
-		$tiaacref_ids{"TBPPX"} = "TIAA-CREF Bond Plus Fund (Premier)";
-		$tiaacref_ids{"TEDPX"} = "TIAA-CREF Emerging Markets Debt Fund (Premier)";
-		$tiaacref_ids{"TEMPX"} = "TIAA-CREF Emerging Markets Equity Fund (Premier)";
-		$tiaacref_ids{"TEQPX"} = "TIAA-CREF Emerging Markets Equity Index Fund (Premier)";
-		$tiaacref_ids{"TCEPX"} = "TIAA-CREF Equity Index Fund (Premier)";
-		$tiaacref_ids{"TNRPX"} = "TIAA-CREF Global Natural Resources Fund (Premier)";
-		$tiaacref_ids{"TRPGX"} = "TIAA-CREF Growth & Income Fund (Premier)";
-		$tiaacref_ids{"TIHPX"} = "TIAA-CREF High Yield Fund (Premier)";
-		$tiaacref_ids{"TIKPX"} = "TIAA-CREF Inflation-Linked Bond Fund (Premier)";
-		$tiaacref_ids{"TIOPX"} = "TIAA-CREF International Opportunities Fund (Premier)";
-		$tiaacref_ids{"TREPX"} = "TIAA-CREF International Equity Fund (Premier)";
-		$tiaacref_ids{"TRIPX"} = "TIAA-CREF International Equity Index Fund (Premier)";
-		$tiaacref_ids{"TILPX"} = "TIAA-CREF Large-Cap Growth Fund (Premier)";
-		$tiaacref_ids{"TRCPX"} = "TIAA-CREF Large-Cap Value Fund (Premier)";
-		$tiaacref_ids{"TCTPX"} = "TIAA-CREF Lifecycle 2010 Fund (Premier)";
-		$tiaacref_ids{"TCFPX"} = "TIAA-CREF Lifecycle 2015 Fund (Premier)";
-		$tiaacref_ids{"TCWPX"} = "TIAA-CREF Lifecycle 2020 Fund (Premier)";
-		$tiaacref_ids{"TCQPX"} = "TIAA-CREF Lifecycle 2025 Fund (Premier)";
-		$tiaacref_ids{"TCHPX"} = "TIAA-CREF Lifecycle 2030 Fund (Premier)";
-		$tiaacref_ids{"TCYPX"} = "TIAA-CREF Lifecycle 2035 Fund (Premier)";
-		$tiaacref_ids{"TCZPX"} = "TIAA-CREF Lifecycle 2040 Fund (Premier)";
-		$tiaacref_ids{"TTFPX"} = "TIAA-CREF Lifecycle 2045 Fund (Premier)";
-		$tiaacref_ids{"TCLPX"} = "TIAA-CREF Lifecycle 2050 Fund (Premier)";
-		$tiaacref_ids{"TTRPX"} = "TIAA-CREF Lifecycle 2055 Fund (Premier)";
-		$tiaacref_ids{"TLXPX"} = "TIAA-CREF Lifecycle 2060 Fund (Premier)";
-		$tiaacref_ids{"TLTPX"} = "TIAA-CREF Lifecycle Index 2010 Fund (Premier)";
-		$tiaacref_ids{"TLFPX"} = "TIAA-CREF Lifecycle Index 2015 Fund (Premier)";
-		$tiaacref_ids{"TLWPX"} = "TIAA-CREF Lifecycle Index 2020 Fund (Premier)";
-		$tiaacref_ids{"TLVPX"} = "TIAA-CREF Lifecycle Index 2025 Fund (Premier)";
-		$tiaacref_ids{"TLHPX"} = "TIAA-CREF Lifecycle Index 2030 Fund (Premier)";
-		$tiaacref_ids{"TLYPX"} = "TIAA-CREF Lifecycle Index 2035 Fund (Premier)";
-		$tiaacref_ids{"TLPRX"} = "TIAA-CREF Lifecycle Index 2040 Fund (Premier)";
-		$tiaacref_ids{"TLMPX"} = "TIAA-CREF Lifecycle Index 2045 Fund (Premier)";
-		$tiaacref_ids{"TLLPX"} = "TIAA-CREF Lifecycle Index 2050 Fund (Premier)";
-		$tiaacref_ids{"TTIPX"} = "TIAA-CREF Lifecycle Index 2055 Fund (Premier)";
-		$tiaacref_ids{"TVIPX"} = "TIAA-CREF Lifecycle Index 2060 Fund (Premier)";
-		$tiaacref_ids{"TLIPX"} = "TIAA-CREF Lifecycle Index Retirement Income Fund (Premier)";
-		$tiaacref_ids{"TPILX"} = "TIAA-CREF Lifecycle Retirement Income Fund (Premier)";
-		$tiaacref_ids{"TSAPX"} = "TIAA-CREF Lifestyle Aggressive Growth Fund (Premier)";
-		$tiaacref_ids{"TLSPX"} = "TIAA-CREF Lifestyle Conservative Fund (Premier)";
-		$tiaacref_ids{"TSGPX"} = "TIAA-CREF Lifestyle Growth Fund (Premier)";
-		$tiaacref_ids{"TSIPX"} = "TIAA-CREF Lifestyle Income Fund (Premier)";
-		$tiaacref_ids{"TSMPX"} = "TIAA-CREF Lifestyle Moderate Fund (Premier)";
-		$tiaacref_ids{"TRGPX"} = "TIAA-CREF Mid-Cap Growth Fund (Premier)";
-		$tiaacref_ids{"TRVPX"} = "TIAA-CREF Mid-Cap Value Fund (Premier)";
-		$tiaacref_ids{"TPPXX"} = "TIAA-CREF Money Market Fund (Premier)";
-		$tiaacref_ids{"TRRPX"} = "TIAA-CREF Real Estate Securities Fund (Premier)";
-		$tiaacref_ids{"TSTPX"} = "TIAA-CREF Short-Term Bond Fund (Premier)";
-		$tiaacref_ids{"TSRPX"} = "TIAA-CREF Small-Cap Equity Fund (Premier)";
-		$tiaacref_ids{"TSBPX"} = "TIAA-CREF Social Choice Bond Fund (Premier)";
-		$tiaacref_ids{"TRPSX"} = "TIAA-CREF Social Choice Equity Fund (Premier)";
-	}
+sub tiaacref {
 
-	if (! %tiaacref_vals) {
-		$tiaacref_vals{"CREFbond"} = "41081991";
-		$tiaacref_vals{"QCBMPX"} = "268585732";
-		$tiaacref_vals{"QCBMIX"} = "268581927";
-		$tiaacref_vals{"CREFequi"} = "41082540";
-		$tiaacref_vals{"QCEQPX"} = "268568309";
-		$tiaacref_vals{"QCEQIX"} = "268561119";
-		$tiaacref_vals{"CREFglob"} = "41081992";
-		$tiaacref_vals{"QCGLPX"} = "268563498";
-		$tiaacref_vals{"QCGLIX"} = "268551676";
-		$tiaacref_vals{"CREFgrow"} = "41082544";
-		$tiaacref_vals{"QCGRPX"} = "268527829";
-		$tiaacref_vals{"QCGRIX"} = "268576313";
-		$tiaacref_vals{"CREFinfb"} = "41088773";
-		$tiaacref_vals{"QCILPX"} = "268587933";
-		$tiaacref_vals{"QCILIX"} = "268572721";
-		$tiaacref_vals{"CREFmony"} = "41081993";
-		$tiaacref_vals{"QCMMPX"} = "268532453";
-		$tiaacref_vals{"QCMMIX"} = "268569116";
-		$tiaacref_vals{"CREFsoci"} = "41081994";
-		$tiaacref_vals{"QCSCPX"} = "268580724";
-		$tiaacref_vals{"QCSCIX"} = "268585136";
-		$tiaacref_vals{"CREFstok"} = "41081995";
-		$tiaacref_vals{"QCSTPX"} = "268540687";
-		$tiaacref_vals{"QCSTIX"} = "268555492";
-		$tiaacref_vals{"TIAAreal"} = "41091375";
-		$tiaacref_vals{"TIDRX"} = "4530828";
-		$tiaacref_vals{"TBIRX"} = "20739662";
-		$tiaacref_vals{"TCBRX"} = "4530816";
-		$tiaacref_vals{"TEDTX"} = "78873869";
-		$tiaacref_vals{"TEMSX"} = "26176543";
-		$tiaacref_vals{"TEQSX"} = "26176547";
-		$tiaacref_vals{"TIQRX"} = "4530786";
-		$tiaacref_vals{"TNRRX"} = "39444919";
-		$tiaacref_vals{"TRGIX"} = "312536";
-		$tiaacref_vals{"TIHRX"} = "4530821";
-		$tiaacref_vals{"TIKRX"} = "4530829";
-		$tiaacref_vals{"TRERX"} = "302323";
-		$tiaacref_vals{"TRIEX"} = "300269";
-		$tiaacref_vals{"TIOTX"} = "57085015";
-		$tiaacref_vals{"TILRX"} = "4530785";
-		$tiaacref_vals{"TRIRX"} = "299525";
-		$tiaacref_vals{"TRLCX"} = "301332";
-		$tiaacref_vals{"TRCVX"} = "304333";
-		$tiaacref_vals{"TCLEX"} = "302817";
-		$tiaacref_vals{"TCLIX"} = "302393";
-		$tiaacref_vals{"TCLTX"} = "307774";
-		$tiaacref_vals{"TCLFX"} = "313994";
-		$tiaacref_vals{"TCLNX"} = "307240";
-		$tiaacref_vals{"TCLRX"} = "309003";
-		$tiaacref_vals{"TCLOX"} = "300959";
-		$tiaacref_vals{"TTFRX"} = "9467597";
-		$tiaacref_vals{"TLFRX"} = "9467596";
-		$tiaacref_vals{"TTRLX"} = "34211330";
-		$tiaacref_vals{"TLXRX"} = "78873871";
-		$tiaacref_vals{"TLTRX"} = "21066482";
-		$tiaacref_vals{"TLGRX"} = "21066496";
-		$tiaacref_vals{"TLWRX"} = "21066479";
-		$tiaacref_vals{"TLQRX"} = "21066485";
-		$tiaacref_vals{"TLHRX"} = "21066435";
-		$tiaacref_vals{"TLYRX"} = "21066475";
-		$tiaacref_vals{"TLZRX"} = "21066473";
-		$tiaacref_vals{"TLMRX"} = "21066488";
-		$tiaacref_vals{"TLLRX"} = "21066490";
-		$tiaacref_vals{"TTIRX"} = "34211328";
-		$tiaacref_vals{"TVITX"} = "78873875";
-		$tiaacref_vals{"TRCIX"} = "21066468";
-		$tiaacref_vals{"TLIRX"} = "9467594";
-		$tiaacref_vals{"TSARX"} = "40508431";
-		$tiaacref_vals{"TSCTX"} = "40508433";
-		$tiaacref_vals{"TSGRX"} = "40508437";
-		$tiaacref_vals{"TLSRX"} = "40508427";
-		$tiaacref_vals{"TSMTX"} = "40508460";
-		$tiaacref_vals{"TITRX"} = "4530825";
-		$tiaacref_vals{"TRGMX"} = "305499";
-		$tiaacref_vals{"TRVRX"} = "315272";
-		$tiaacref_vals{"TIEXX"} = "4530771";
-		$tiaacref_vals{"TRRSX"} = "300081";
-		$tiaacref_vals{"TRSPX"} = "306105";
-		$tiaacref_vals{"TISRX"} = "4530818";
-		$tiaacref_vals{"TRBIX"} = "314644";
-		$tiaacref_vals{"TRSEX"} = "299968";
-		$tiaacref_vals{"TSBBX"} = "49604881";
-		$tiaacref_vals{"TRSCX"} = "300078";
-		$tiaacref_vals{"TIBDX"} = "307276";
-		$tiaacref_vals{"TBIIX"} = "20739664";
-		$tiaacref_vals{"TIBFX"} = "4530820";
-		$tiaacref_vals{"TEDNX"} = "78873868";
-		$tiaacref_vals{"TEMLX"} = "26176540";
-		$tiaacref_vals{"TEQLX"} = "26176544";
-		$tiaacref_vals{"TFIIX"} = "9467603";
-		$tiaacref_vals{"TLIIX"} = "9467602";
-		$tiaacref_vals{"TEVIX"} = "9467606";
-		$tiaacref_vals{"TIEIX"} = "301718";
-		$tiaacref_vals{"TNRIX"} = "39444916";
-		$tiaacref_vals{"TIGRX"} = "314719";
-		$tiaacref_vals{"TIHYX"} = "4530798";
-		$tiaacref_vals{"TIILX"} = "316693";
-		$tiaacref_vals{"TIIEX"} = "305980";
-		$tiaacref_vals{"TCIEX"} = "303673";
-		$tiaacref_vals{"TIOIX"} = "57085012";
-		$tiaacref_vals{"TILGX"} = "4530800";
-		$tiaacref_vals{"TILIX"} = "297809";
-		$tiaacref_vals{"TRLIX"} = "300692";
-		$tiaacref_vals{"TILVX"} = "302308";
-		$tiaacref_vals{"TCTIX"} = "4912376";
-		$tiaacref_vals{"TCNIX"} = "4912355";
-		$tiaacref_vals{"TCWIX"} = "4912377";
-		$tiaacref_vals{"TCYIX"} = "4912384";
-		$tiaacref_vals{"TCRIX"} = "4912364";
-		$tiaacref_vals{"TCIIX"} = "4912375";
-		$tiaacref_vals{"TCOIX"} = "4912387";
-		$tiaacref_vals{"TTFIX"} = "9467607";
-		$tiaacref_vals{"TFTIX"} = "9467601";
-		$tiaacref_vals{"TTRIX"} = "34211329";
-		$tiaacref_vals{"TLXNX"} = "78873872";
-		$tiaacref_vals{"TLTIX"} = "21066484";
-		$tiaacref_vals{"TLFIX"} = "21066498";
-		$tiaacref_vals{"TLWIX"} = "21066480";
-		$tiaacref_vals{"TLQIX"} = "21066486";
-		$tiaacref_vals{"TLHIX"} = "21066495";
-		$tiaacref_vals{"TLYIX"} = "21066477";
-		$tiaacref_vals{"TLZIX"} = "21066474";
-		$tiaacref_vals{"TLXIX"} = "21066478";
-		$tiaacref_vals{"TLLIX"} = "21066492";
-		$tiaacref_vals{"TTIIX"} = "34211326";
-		$tiaacref_vals{"TVIIX"} = "78873873";
-		$tiaacref_vals{"TRILX"} = "21066463";
-		$tiaacref_vals{"TLRIX"} = "9467595";
-		$tiaacref_vals{"TSAIX"} = "40508428";
-		$tiaacref_vals{"TCSIX"} = "40508425";
-		$tiaacref_vals{"TSGGX"} = "40508434";
-		$tiaacref_vals{"TSITX"} = "40508450";
-		$tiaacref_vals{"TSIMX"} = "40508443";
-		$tiaacref_vals{"TIMIX"} = "4530787";
-		$tiaacref_vals{"TRPWX"} = "297210";
-		$tiaacref_vals{"TIMVX"} = "316178";
-		$tiaacref_vals{"TCIXX"} = "313650";
-		$tiaacref_vals{"TIREX"} = "303475";
-		$tiaacref_vals{"TISPX"} = "306658";
-		$tiaacref_vals{"TISIX"} = "4530784";
-		$tiaacref_vals{"TISBX"} = "309018";
-		$tiaacref_vals{"TISEX"} = "301622";
-		$tiaacref_vals{"TSBIX"} = "49604882";
-		$tiaacref_vals{"TISCX"} = "301897";
-		$tiaacref_vals{"TITIX"} = "4530819";
-		$tiaacref_vals{"TIORX"} = "4530794";
-		$tiaacref_vals{"TBILX"} = "20739663";
-		$tiaacref_vals{"TCBPX"} = "4530788";
-		$tiaacref_vals{"TEDLX"} = "78873866";
-		$tiaacref_vals{"TEMRX"} = "26176542";
-		$tiaacref_vals{"TEQKX"} = "26176545";
-		$tiaacref_vals{"TINRX"} = "4530797";
-		$tiaacref_vals{"TNRLX"} = "39444917";
-		$tiaacref_vals{"TIIRX"} = "4530790";
-		$tiaacref_vals{"TIYRX"} = "4530830";
-		$tiaacref_vals{"TCILX"} = "313727";
-		$tiaacref_vals{"TIERX"} = "4530827";
-		$tiaacref_vals{"TIOSX"} = "57085014";
-		$tiaacref_vals{"TIRTX"} = "4530791";
-		$tiaacref_vals{"TCLCX"} = "302696";
-		$tiaacref_vals{"TLRRX"} = "9467600";
-		$tiaacref_vals{"TSALX"} = "40508429";
-		$tiaacref_vals{"TSCLX"} = "40508432";
-		$tiaacref_vals{"TSGLX"} = "40508435";
-		$tiaacref_vals{"TSILX"} = "40508438";
-		$tiaacref_vals{"TSMLX"} = "40508453";
-		$tiaacref_vals{"TIMRX"} = "4530817";
-		$tiaacref_vals{"TCMGX"} = "305208";
-		$tiaacref_vals{"TCMVX"} = "313995";
-		$tiaacref_vals{"TIRXX"} = "4530775";
-		$tiaacref_vals{"TCREX"} = "309567";
-		$tiaacref_vals{"TCTRX"} = "4530822";
-		$tiaacref_vals{"TCSEX"} = "297477";
-		$tiaacref_vals{"TSBRX"} = "49604884";
-		$tiaacref_vals{"TICRX"} = "4530792";
-		$tiaacref_vals{"TIXRX"} = "4530793";
-		$tiaacref_vals{"TIDPX"} = "21066506";
-		$tiaacref_vals{"TBIPX"} = "21066534";
-		$tiaacref_vals{"TBPPX"} = "21066533";
-		$tiaacref_vals{"TEDPX"} = "78873867";
-		$tiaacref_vals{"TEMPX"} = "26176541";
-		$tiaacref_vals{"TEQPX"} = "26176546";
-		$tiaacref_vals{"TCEPX"} = "21066530";
-		$tiaacref_vals{"TNRPX"} = "39444918";
-		$tiaacref_vals{"TRPGX"} = "21066461";
-		$tiaacref_vals{"TIHPX"} = "21066501";
-		$tiaacref_vals{"TIKPX"} = "21066500";
-		$tiaacref_vals{"TREPX"} = "21066466";
-		$tiaacref_vals{"TRIPX"} = "21066462";
-		$tiaacref_vals{"TIOPX"} = "57085013";
-		$tiaacref_vals{"TILPX"} = "21066499";
-		$tiaacref_vals{"TRCPX"} = "21066467";
-		$tiaacref_vals{"TCTPX"} = "21066521";
-		$tiaacref_vals{"TCFPX"} = "21066528";
-		$tiaacref_vals{"TCWPX"} = "21066518";
-		$tiaacref_vals{"TCQPX"} = "21066522";
-		$tiaacref_vals{"TCHPX"} = "21066527";
-		$tiaacref_vals{"TCYPX"} = "21066517";
-		$tiaacref_vals{"TCZPX"} = "21066516";
-		$tiaacref_vals{"TTFPX"} = "21066444";
-		$tiaacref_vals{"TCLPX"} = "21066526";
-		$tiaacref_vals{"TTRPX"} = "34211331";
-		$tiaacref_vals{"TLXPX"} = "78873870";
-		$tiaacref_vals{"TLTPX"} = "21066483";
-		$tiaacref_vals{"TLFPX"} = "21066497";
-		$tiaacref_vals{"TLWPX"} = "21066434";
-		$tiaacref_vals{"TLVPX"} = "21066481";
-		$tiaacref_vals{"TLHPX"} = "21066494";
-		$tiaacref_vals{"TLYPX"} = "21066476";
-		$tiaacref_vals{"TLPRX"} = "21066487";
-		$tiaacref_vals{"TLMPX"} = "21066489";
-		$tiaacref_vals{"TLLPX"} = "21066491";
-		$tiaacref_vals{"TTIPX"} = "34211327";
-		$tiaacref_vals{"TVIPX"} = "78873874";
-		$tiaacref_vals{"TLIPX"} = "21066493";
-		$tiaacref_vals{"TPILX"} = "21066470";
-		$tiaacref_vals{"TSAPX"} = "40508430";
-		$tiaacref_vals{"TLSPX"} = "40508426";
-		$tiaacref_vals{"TSGPX"} = "40508436";
-		$tiaacref_vals{"TSIPX"} = "40508451";
-		$tiaacref_vals{"TSMPX"} = "40508456";
-		$tiaacref_vals{"TRGPX"} = "21066464";
-		$tiaacref_vals{"TRVPX"} = "21066455";
-		$tiaacref_vals{"TPPXX"} = "21066469";
-		$tiaacref_vals{"TRRPX"} = "21066459";
-		$tiaacref_vals{"TSTPX"} = "21066445";
-		$tiaacref_vals{"TSRPX"} = "21066446";
-		$tiaacref_vals{"TSBPX"} = "49604883";
-		$tiaacref_vals{"TRPSX"} = "21066460";
-	}
+    my $quoter = shift;
 
-#The location doesn't matter anymore.
-#I'm leaving this data structure in place in case it changes again
-#FBN 23/JAN/04
+    my @symbols = @_;
+    return unless scalar @symbols;
 
-	if (! %tiaacref_locs) {
-		$tiaacref_locs{"CREFbond"} = 1;
-		$tiaacref_locs{"QCBMPX"} = 1;
-		$tiaacref_locs{"QCBMIX"} = 1;
-		$tiaacref_locs{"CREFequi"} = 1;
-		$tiaacref_locs{"QCEQPX"} = 1;
-		$tiaacref_locs{"QCEQIX"} = 1;
-		$tiaacref_locs{"CREFglob"} = 1;
-		$tiaacref_locs{"QCGLPX"} = 1;
-		$tiaacref_locs{"QCGLIX"} = 1;
-		$tiaacref_locs{"CREFgrow"} = 1;
-		$tiaacref_locs{"QCGRPX"} = 1;
-		$tiaacref_locs{"QCGRIX"} = 1;
-		$tiaacref_locs{"CREFinfb"} = 1;
-		$tiaacref_locs{"QCILPX"} = 1;
-		$tiaacref_locs{"QCILIX"} = 1;
-		$tiaacref_locs{"CREFmony"} = 1;
-		$tiaacref_locs{"QCMMPX"} = 1;
-		$tiaacref_locs{"QCMMIX"} = 1;
-		$tiaacref_locs{"CREFsoci"} = 1;
-		$tiaacref_locs{"QCSCPX"} = 1;
-		$tiaacref_locs{"QCSCIX"} = 1;
-		$tiaacref_locs{"CREFstok"} = 1;
-		$tiaacref_locs{"QCSTPX"} = 1;
-		$tiaacref_locs{"QCSTIX"} = 1;
-		$tiaacref_locs{"TIAAreal"} = 1;
-		$tiaacref_locs{"TIDRX"} = 1;
-		$tiaacref_locs{"TBIRX"} = 1;
-		$tiaacref_locs{"TCBRX"} = 1;
-		$tiaacref_locs{"TEDTX"} = 1;
-		$tiaacref_locs{"TEMSX"} = 1;
-		$tiaacref_locs{"TEQSX"} = 1;
-		$tiaacref_locs{"TIQRX"} = 1;
-		$tiaacref_locs{"TNRRX"} = 1;
-		$tiaacref_locs{"TRGIX"} = 1;
-		$tiaacref_locs{"TIHRX"} = 1;
-		$tiaacref_locs{"TIKRX"} = 1;
-		$tiaacref_locs{"TRERX"} = 1;
-		$tiaacref_locs{"TRIEX"} = 1;
-		$tiaacref_locs{"TIOTX"} = 1;
-		$tiaacref_locs{"TILRX"} = 1;
-		$tiaacref_locs{"TRIRX"} = 1;
-		$tiaacref_locs{"TRLCX"} = 1;
-		$tiaacref_locs{"TRCVX"} = 1;
-		$tiaacref_locs{"TCLEX"} = 1;
-		$tiaacref_locs{"TCLIX"} = 1;
-		$tiaacref_locs{"TCLTX"} = 1;
-		$tiaacref_locs{"TCLFX"} = 1;
-		$tiaacref_locs{"TCLNX"} = 1;
-		$tiaacref_locs{"TCLRX"} = 1;
-		$tiaacref_locs{"TCLOX"} = 1;
-		$tiaacref_locs{"TTFRX"} = 1;
-		$tiaacref_locs{"TLFRX"} = 1;
-		$tiaacref_locs{"TTRLX"} = 1;
-		$tiaacref_locs{"TLXRX"} = 1;
-		$tiaacref_locs{"TLTRX"} = 1;
-		$tiaacref_locs{"TLGRX"} = 1;
-		$tiaacref_locs{"TLWRX"} = 1;
-		$tiaacref_locs{"TLQRX"} = 1;
-		$tiaacref_locs{"TLHRX"} = 1;
-		$tiaacref_locs{"TLYRX"} = 1;
-		$tiaacref_locs{"TLZRX"} = 1;
-		$tiaacref_locs{"TLMRX"} = 1;
-		$tiaacref_locs{"TLLRX"} = 1;
-		$tiaacref_locs{"TTIRX"} = 1;
-		$tiaacref_locs{"TVITX"} = 1;
-		$tiaacref_locs{"TRCIX"} = 1;
-		$tiaacref_locs{"TLIRX"} = 1;
-		$tiaacref_locs{"TSARX"} = 1;
-		$tiaacref_locs{"TSCTX"} = 1;
-		$tiaacref_locs{"TSGRX"} = 1;
-		$tiaacref_locs{"TLSRX"} = 1;
-		$tiaacref_locs{"TSMTX"} = 1;
-		$tiaacref_locs{"TITRX"} = 1;
-		$tiaacref_locs{"TRGMX"} = 1;
-		$tiaacref_locs{"TRVRX"} = 1;
-		$tiaacref_locs{"TIEXX"} = 1;
-		$tiaacref_locs{"TRRSX"} = 1;
-		$tiaacref_locs{"TRSPX"} = 1;
-		$tiaacref_locs{"TISRX"} = 1;
-		$tiaacref_locs{"TRBIX"} = 1;
-		$tiaacref_locs{"TRSEX"} = 1;
-		$tiaacref_locs{"TSBBX"} = 1;
-		$tiaacref_locs{"TRSCX"} = 1;
-		$tiaacref_locs{"TIBDX"} = 1;
-		$tiaacref_locs{"TBIIX"} = 1;
-		$tiaacref_locs{"TIBFX"} = 1;
-		$tiaacref_locs{"TEDNX"} = 1;
-		$tiaacref_locs{"TEMLX"} = 1;
-		$tiaacref_locs{"TEQLX"} = 1;
-		$tiaacref_locs{"TFIIX"} = 1;
-		$tiaacref_locs{"TLIIX"} = 1;
-		$tiaacref_locs{"TEVIX"} = 1;
-		$tiaacref_locs{"TIEIX"} = 1;
-		$tiaacref_locs{"TNRIX"} = 1;
-		$tiaacref_locs{"TIGRX"} = 1;
-		$tiaacref_locs{"TIHYX"} = 1;
-		$tiaacref_locs{"TIILX"} = 1;
-		$tiaacref_locs{"TIIEX"} = 1;
-		$tiaacref_locs{"TCIEX"} = 1;
-		$tiaacref_locs{"TIOIX"} = 1;
-		$tiaacref_locs{"TILGX"} = 1;
-		$tiaacref_locs{"TILIX"} = 1;
-		$tiaacref_locs{"TRLIX"} = 1;
-		$tiaacref_locs{"TILVX"} = 1;
-		$tiaacref_locs{"TCTIX"} = 1;
-		$tiaacref_locs{"TCNIX"} = 1;
-		$tiaacref_locs{"TCWIX"} = 1;
-		$tiaacref_locs{"TCYIX"} = 1;
-		$tiaacref_locs{"TCRIX"} = 1;
-		$tiaacref_locs{"TCIIX"} = 1;
-		$tiaacref_locs{"TCOIX"} = 1;
-		$tiaacref_locs{"TTFIX"} = 1;
-		$tiaacref_locs{"TFTIX"} = 1;
-		$tiaacref_locs{"TTRIX"} = 1;
-		$tiaacref_locs{"TLXNX"} = 1;
-		$tiaacref_locs{"TLTIX"} = 1;
-		$tiaacref_locs{"TLFIX"} = 1;
-		$tiaacref_locs{"TLWIX"} = 1;
-		$tiaacref_locs{"TLQIX"} = 1;
-		$tiaacref_locs{"TLHIX"} = 1;
-		$tiaacref_locs{"TLYIX"} = 1;
-		$tiaacref_locs{"TLZIX"} = 1;
-		$tiaacref_locs{"TLXIX"} = 1;
-		$tiaacref_locs{"TLLIX"} = 1;
-		$tiaacref_locs{"TTIIX"} = 1;
-		$tiaacref_locs{"TVIIX"} = 1;
-		$tiaacref_locs{"TRILX"} = 1;
-		$tiaacref_locs{"TLRIX"} = 1;
-		$tiaacref_locs{"TSAIX"} = 1;
-		$tiaacref_locs{"TCSIX"} = 1;
-		$tiaacref_locs{"TSGGX"} = 1;
-		$tiaacref_locs{"TSITX"} = 1;
-		$tiaacref_locs{"TSIMX"} = 1;
-		$tiaacref_locs{"TIMIX"} = 1;
-		$tiaacref_locs{"TRPWX"} = 1;
-		$tiaacref_locs{"TIMVX"} = 1;
-		$tiaacref_locs{"TCIXX"} = 1;
-		$tiaacref_locs{"TIREX"} = 1;
-		$tiaacref_locs{"TISPX"} = 1;
-		$tiaacref_locs{"TISIX"} = 1;
-		$tiaacref_locs{"TISBX"} = 1;
-		$tiaacref_locs{"TISEX"} = 1;
-		$tiaacref_locs{"TSBIX"} = 1;
-		$tiaacref_locs{"TISCX"} = 1;
-		$tiaacref_locs{"TITIX"} = 1;
-		$tiaacref_locs{"TIORX"} = 1;
-		$tiaacref_locs{"TBILX"} = 1;
-		$tiaacref_locs{"TCBPX"} = 1;
-		$tiaacref_locs{"TEDLX"} = 1;
-		$tiaacref_locs{"TEMRX"} = 1;
-		$tiaacref_locs{"TEQKX"} = 1;
-		$tiaacref_locs{"TINRX"} = 1;
-		$tiaacref_locs{"TNRLX"} = 1;
-		$tiaacref_locs{"TIIRX"} = 1;
-		$tiaacref_locs{"TIYRX"} = 1;
-		$tiaacref_locs{"TCILX"} = 1;
-		$tiaacref_locs{"TIERX"} = 1;
-		$tiaacref_locs{"TIOSX"} = 1;
-		$tiaacref_locs{"TIRTX"} = 1;
-		$tiaacref_locs{"TCLCX"} = 1;
-		$tiaacref_locs{"TLRRX"} = 1;
-		$tiaacref_locs{"TSALX"} = 1;
-		$tiaacref_locs{"TSCLX"} = 1;
-		$tiaacref_locs{"TSGLX"} = 1;
-		$tiaacref_locs{"TSILX"} = 1;
-		$tiaacref_locs{"TSMLX"} = 1;
-		$tiaacref_locs{"TIMRX"} = 1;
-		$tiaacref_locs{"TCMGX"} = 1;
-		$tiaacref_locs{"TCMVX"} = 1;
-		$tiaacref_locs{"TIRXX"} = 1;
-		$tiaacref_locs{"TCREX"} = 1;
-		$tiaacref_locs{"TCTRX"} = 1;
-		$tiaacref_locs{"TCSEX"} = 1;
-		$tiaacref_locs{"TSBRX"} = 1;
-		$tiaacref_locs{"TICRX"} = 1;
-		$tiaacref_locs{"TIXRX"} = 1;
-		$tiaacref_locs{"TIDPX"} = 1;
-		$tiaacref_locs{"TBIPX"} = 1;
-		$tiaacref_locs{"TBPPX"} = 1;
-		$tiaacref_locs{"TEDPX"} = 1;
-		$tiaacref_locs{"TEMPX"} = 1;
-		$tiaacref_locs{"TEQPX"} = 1;
-		$tiaacref_locs{"TCEPX"} = 1;
-		$tiaacref_locs{"TNRPX"} = 1;
-		$tiaacref_locs{"TRPGX"} = 1;
-		$tiaacref_locs{"TIHPX"} = 1;
-		$tiaacref_locs{"TIKPX"} = 1;
-		$tiaacref_locs{"TREPX"} = 1;
-		$tiaacref_locs{"TRIPX"} = 1;
-		$tiaacref_locs{"TIOPX"} = 1;
-		$tiaacref_locs{"TILPX"} = 1;
-		$tiaacref_locs{"TRCPX"} = 1;
-		$tiaacref_locs{"TCTPX"} = 1;
-		$tiaacref_locs{"TCFPX"} = 1;
-		$tiaacref_locs{"TCWPX"} = 1;
-		$tiaacref_locs{"TCQPX"} = 1;
-		$tiaacref_locs{"TCHPX"} = 1;
-		$tiaacref_locs{"TCYPX"} = 1;
-		$tiaacref_locs{"TCZPX"} = 1;
-		$tiaacref_locs{"TTFPX"} = 1;
-		$tiaacref_locs{"TCLPX"} = 1;
-		$tiaacref_locs{"TTRPX"} = 1;
-		$tiaacref_locs{"TLXPX"} = 1;
-		$tiaacref_locs{"TLTPX"} = 1;
-		$tiaacref_locs{"TLFPX"} = 1;
-		$tiaacref_locs{"TLWPX"} = 1;
-		$tiaacref_locs{"TLVPX"} = 1;
-		$tiaacref_locs{"TLHPX"} = 1;
-		$tiaacref_locs{"TLYPX"} = 1;
-		$tiaacref_locs{"TLPRX"} = 1;
-		$tiaacref_locs{"TLMPX"} = 1;
-		$tiaacref_locs{"TLLPX"} = 1;
-		$tiaacref_locs{"TTIPX"} = 1;
-		$tiaacref_locs{"TVIPX"} = 1;
-		$tiaacref_locs{"TLIPX"} = 1;
-		$tiaacref_locs{"TPILX"} = 1;
-		$tiaacref_locs{"TSAPX"} = 1;
-		$tiaacref_locs{"TLSPX"} = 1;
-		$tiaacref_locs{"TSGPX"} = 1;
-		$tiaacref_locs{"TSIPX"} = 1;
-		$tiaacref_locs{"TSMPX"} = 1;
-		$tiaacref_locs{"TRGPX"} = 1;
-		$tiaacref_locs{"TRVPX"} = 1;
-		$tiaacref_locs{"TPPXX"} = 1;
-		$tiaacref_locs{"TRRPX"} = 1;
-		$tiaacref_locs{"TSTPX"} = 1;
-		$tiaacref_locs{"TSRPX"} = 1;
-		$tiaacref_locs{"TSBPX"} = 1;
-		$tiaacref_locs{"TRPSX"} = 1;
-	}
-	my(@funds) = @_;
-	return unless @funds;
-	my(@line); #holds the return from parse_csv
-	my(%info);
-	my(%check); #holds success value if data returned
-	my($ua,$urlc,$urlt); #useragent and target urls
-	my($cntc,$cntt); #counters for each of the two url containers
-	my($reply,$qdata); #the reply from TIAA-CREF's cgi and a buffer for the data
+    my %info;
+    my $ua = $quoter->user_agent;
 
-	$urlc = $CREF_URL;
-	$urlt = $TIAA_URL;
+    # The TIAA data service wants a start and end date. To guarantee data,
+    # ask for 7 days of quotes, and only take the first (most recent) one.
+    my $end = localtime;
+    my $start = $end - ONE_WEEK;
 
-#The new TIAA-CREF website asks for start and end dates. To guarantee data,
-#ask for 7 days of quotes, and only take the first (most recent) one.
-	my(@starttime, $startdate);
-	@starttime = localtime(time-7*86400);
-	$starttime[5] += 1900;
-	$starttime[4] += 1;
-	$startdate = $starttime[5] . "-" . $starttime[4] . "-" . $starttime[3];
-	my(@endtime, $enddate);
-	@endtime = localtime(time);
-	$endtime[5] += 1900;
-	$endtime[4] += 1;
-	$enddate = $endtime[5] . "-" . $endtime[4] . "-" . $endtime[3];
+    #Need to fetch a session key first
+    my $session_key;
+    my $fail_msg;
+    my $res = $ua->get( $TIAA_MAIN_URL );
+    if (! $res->is_success) {
+        $fail_msg = "Failed to fetch TIAA page from $TIAA_MAIN_URL. It may be"
+          . " that the link has changed. HTTP status returned: "
+          . $res->status_line;
+    }
+    else {
+        if ($res->content =~ /\bMODKey=\'([^']+)'/) {
+            $session_key = $1;
+        }
+        else {
+            $fail_msg = "Failed to fetch session key from TIAA site. Please"
+            . " contact the developers for further assistance."
+        }
+    }
+    if (defined $fail_msg) {
+        for my $symbol (@symbols) {
+            $info{ $symbol, "success"  } = 0;
+            $info{ $symbol, "errormsg" } = $fail_msg;
+        }
+        return %info if wantarray;
+        return \%info;
+    }
 
-	$urlc .= "&NavStart=" . $startdate . "&NavEnd=" . $enddate;
+    SYMBOL:
+    for my $symbol (@symbols) {
 
-#Initialize counters for the two types of URL. If either counter is zero, then
-# that URL will not be retrieved. This is less technically clever than testing
-#the URL string itself with m/yes/, but its faster.
-	$cntc = 0;
-	$cntt = 0;
-	foreach my $fund (@funds) {
-		if ($tiaacref_ids{$fund}) {
-			if ($tiaacref_locs{$fund} == 1) {
-				$cntc++;
-				$urlc .= "&WSODIssues=" . $tiaacref_vals{$fund};
-			} else {
-				$urlt .= $fund . "=yes&";
-				$cntt++;
-			}
-			$check{$fund} = 0;
-		} else {
-			$info{$fund,"success"} = 0;
-			$info{$fund,"errormsg"} = "Bad symbol";
-		}
-	}
-	$urlc .= "&viewtype=CSV";
-	$urlt .= "selected=1";
+        my $payload = {
+            xids            => [$symbol],
+            exportType      => 'CSV',
+            startDate       => $start->mdy,
+            endDate         => $end->mdy,
+            selectedDetails => '',
+        };
 
-	$qdata ="";
+        my $url = join '?',
+            $TIAA_DATA_URL,
+            $session_key,
+        ;
+        my $res = $ua->post($url, $payload);
+        if (! $res->is_success) {
+            $info{ $symbol, "success"  } = 0;
+            $info{ $symbol, "errormsg" } = "There was an error fetching data"
+              . " for $symbol. HTTP status returned: " . $res->status_line;
+            next SYMBOL;
+        }
 
-	$ua = $quoter->user_agent;
-	if ($cntc) {
-		$reply = $ua->request(GET $urlc);
-		if ($reply ->is_success) {
-			$qdata .= $reply->content;
-		}
-	}
-	if ($cntt) {
-		$reply = $ua->request(GET $urlt);
-		if ($reply ->is_success) {
-			$qdata .= $reply->content;
-		}
-	}
+        # Data returned is in UTF-16-encoded CSV. As we asked for a week of
+        # data, successful queries will likely return multiple lines, but they
+        # are sorted in descending chronological order so we can just take
+        # the first one.
+        my $csv = decode( 'UTF-16LE', $res->content );
+        open my $stream, '<', \$csv;
+        while (my $line = <$stream>) {
 
-	if (length($qdata)) {
-	    $qdata = Encode::decode('utf16le', $qdata);
-		foreach (split(/\012/,$qdata) ){
-			next unless m/.+,.+/;
-			s/[\r\n]+//g;
-			s/^ +//g;
-			s/ +$//g;
-#			@line = split(/,/,$_);
-			@line = $quoter->parse_csv($_);
-			if($line[0] eq "QCBMRX"){$line[0] = "CREFbond";}
-			if($line[0] eq "QCEQRX"){$line[0] = "CREFequi";}
-			if($line[0] eq "QCGLRX"){$line[0] = "CREFglob";}
-			if($line[0] eq "QCGRRX"){$line[0] = "CREFgrow";}
-			if($line[0] eq "QCILRX"){$line[0] = "CREFinfb";}
-			if($line[0] eq "QCMMRX"){$line[0] = "CREFmony";}
-			if($line[0] eq "QCSCRX"){$line[0] = "CREFsoci";}
-			if($line[0] eq "QCSTRX"){$line[0] = "CREFstok";}
-			if($line[0] eq "QREARX"){$line[0] = "TIAAreal";}
-			if (exists $check{$line[0]}) { #did we ask for this data?
-				if($check{$line[0]} == 1){next} #calcisme: this prevents getting more than the first of the quotes
-				$info{$line[0],"symbol"} = $line[0]; #in case the caller needs this in the hash
-				$info{$line[0],"exchange"} = "TIAA-CREF";
-				$info{$line[0],"name"} = $tiaacref_ids{$line[0]};
-				$quoter->store_date(\%info, $line[0], {usdate => $line[2]});
-				$info{$line[0],"nav"} = $line[1];
-				$info{$line[0],"price"} = $info{$line[0],"nav"};
-				$info{$line[0],"success"} = 1; #this contains good data,
-												#beyond a reasonable doubt
-				$info{$line[0],"currency"} = "USD";
-				$info{$line[0],"method"} = "tiaacref";
-				$info{$line[0],"exchange"} = "TIAA-CREF";
-				$check{$line[0]} = 1;
-			} else {
-				$info{$line[0],"success"} = 0;
-				$info{$line[0],"errormsg"} = "Bad data returned";
-			}
-		}
-	} else {
-		foreach $_ (@funds) {
-			$info{$_,"success"} = 0;
-			$info{$_,"errormsg"} = "HTTP error";
-		} # foreach
-	} #if $length(qdata) else
+            chomp $line;
+            my ($description, $price, $date) = split ',', $line;
 
+            # if no data is found for the given symbol, no error is thrown
+            # but the content returned contains a textual error message. In
+            # this case, the latter fields will not be defined.
+            if (! defined $date) {
+                $info{ $symbol, "success"  } = 0;
+                $info{ $symbol, "errormsg" } =
+                    "Error retrieving quote for $symbol - no listing for this"
+                  . " name found. Please check symbol and the two letter"
+                  . " extension (if any)";
+                next SYMBOL;
+            }
+            try {
+                $date = Time::Piece->strptime($date, "%m/%d/%Y");
+            } catch {
+                $info{ $symbol, "success"  } = 0;
+                $info{ $symbol, "errormsg" } =
+                    "Error parsing date ($date) for $symbol. Please"
+                  . " contact the developers for further assistance.";
+                next SYMBOL;
+            };
+            $info{ $symbol, "success"  } = 1;
+            $info{ $symbol, "symbol"   } = $symbol;
+            $info{ $symbol, "exchange" } = "TIAA";
+            $info{ $symbol, "name"     } = $description;
+            $info{ $symbol, "nav"      } = $price;
+            $info{ $symbol, "price"    } = $info{$symbol, "nav"};
+            $info{ $symbol, "currency" } = "USD";
+            $info{ $symbol, "method"   } = "tiaacref";
+            $info{ $symbol, "isodate" }  = $date->ymd;
+            $info{ $symbol, "date" }     = $date->mdy('/');
+            $quoter->store_date(
+                \%info,
+                $symbol,
+                {isodate => $date->ymd}
+            );
 
-	#now check to make sure a value was returned for every symbol asked for
-	foreach my $k (keys %check) {
-		if ($check{$k} == 0) {
-			$info{$k,"success"} = 0;
-			$info{$k,"errormsg"} = "No data returned";
-		}
-	}
+            last; # IMPORTANT: don't parse older data!
 
-	return %info if wantarray;
-	return \%info;
+        }
+
+    }
+
+    return %info if wantarray;
+    return \%info;
+
 }
 
 1;
 
 =head1 NAME
 
-Finance::Quote::Tiaacref	- Obtain quote from TIAA-CREF.
+Finance::Quote::Tiaacref - Obtain quote from TIAA (formerly TIAA-CREF)
 
 =head1 SYNOPSIS
 
@@ -1147,209 +309,11 @@ Finance::Quote::Tiaacref	- Obtain quote from TIAA-CREF.
 
 This module obtains information about TIAA-CREF managed funds.
 
-The following symbols can be used:
-
-    CREF Bond Market Account:	CREFbond
-    CREF Equity Index Account:	CREFequi
-    CREF Global Equities Account:	CREFglob
-    CREF Growth Account:	CREFgrow
-    CREF Inflation-Linked Bond Account:	CREFinfb
-    CREF Money Market Account:	CREFmony
-    CREF Social Choice Account:	CREFsoci
-    CREF Stock Account:	CREFstok
-    TIAA Real Estate Account:	TIAAreal
-    TIAA-CREF Bond Fund (Retirement):	TIDRX
-    TIAA-CREF Bond Index Fund (Retirement):	TBIRX
-    TIAA-CREF Bond Plus Fund (Retirement):	TCBRX
-    TIAA-CREF Emerging Markets Equity Fund (Retirement):	TEMSX
-    TIAA-CREF Emerging Markets Equity Index Fund (Retirement):	TEQSX
-    TIAA-CREF Equity Index Fund (Retirement):	TIQRX
-    TIAA-CREF Global Natural Resources Fund (Retirement):	TNRRX
-    TIAA-CREF Growth & Income Fund (Retirement):	TRGIX
-    TIAA-CREF High Yield Fund (Retirement):	TIHRX
-    TIAA-CREF Inflation-Linked Bond Fund (Retirement):	TIKRX
-    TIAA-CREF International Equity Fund (Retirement):	TRERX
-    TIAA-CREF International Equity Index Fund (Retirement):	TRIEX
-    TIAA-CREF Large-Cap Growth Fund (Retirement):	TILRX
-    TIAA-CREF Large-Cap Growth Index Fund (Retirement):	TRIRX
-    TIAA-CREF Large-Cap Value Fund (Retirement):	TRLCX
-    TIAA-CREF Large-Cap Value Index Fund (Retirement):	TRCVX
-    TIAA-CREF Lifecycle 2010 Fund (Retirement):	TCLEX
-    TIAA-CREF Lifecycle 2015 Fund (Retirement):	TCLIX
-    TIAA-CREF Lifecycle 2020 Fund (Retirement):	TCLTX
-    TIAA-CREF Lifecycle 2025 Fund (Retirement):	TCLFX
-    TIAA-CREF Lifecycle 2030 Fund (Retirement):	TCLNX
-    TIAA-CREF Lifecycle 2035 Fund (Retirement):	TCLRX
-    TIAA-CREF Lifecycle 2040 Fund (Retirement):	TCLOX
-    TIAA-CREF Lifecycle 2045 Fund (Retirement):	TTFRX
-    TIAA-CREF Lifecycle 2050 Fund (Retirement):	TLFRX
-    TIAA-CREF Lifecycle 2055 Fund (Retirement):	TTRLX
-    TIAA-CREF Lifecycle Index 2010 Fund (Retirement):	TLTRX
-    TIAA-CREF Lifecycle Index 2015 Fund (Retirement):	TLGRX
-    TIAA-CREF Lifecycle Index 2020 Fund (Retirement):	TLWRX
-    TIAA-CREF Lifecycle Index 2025 Fund (Retirement):	TLQRX
-    TIAA-CREF Lifecycle Index 2030 Fund (Retirement):	TLHRX
-    TIAA-CREF Lifecycle Index 2035 Fund (Retirement):	TLYRX
-    TIAA-CREF Lifecycle Index 2040 Fund (Retirement):	TLZRX
-    TIAA-CREF Lifecycle Index 2045 Fund (Retirement):	TLMRX
-    TIAA-CREF Lifecycle Index 2050 Fund (Retirement):	TLLRX
-    TIAA-CREF Lifecycle Index 2055 Fund (Retirement):	TTIRX
-    TIAA-CREF Lifecycle Index Retirement Income Fund (Retirement):	TRCIX
-    TIAA-CREF Lifecycle Retirement Income Fund (Retirement):	TLIRX
-    TIAA-CREF Lifestyle Aggressive Growth Fund (Retirement):	TSARX
-    TIAA-CREF Lifestyle Conservative Fund (Retirement):	TSCTX
-    TIAA-CREF Lifestyle Growth Fund (Retirement):	TSGRX
-    TIAA-CREF Lifestyle Income Fund (Retirement):	TLSRX
-    TIAA-CREF Lifestyle Moderate Fund (Retirement):	TSMTX
-    TIAA-CREF Managed Allocation Fund (Retirement):	TITRX
-    TIAA-CREF Mid-Cap Growth Fund (Retirement):	TRGMX
-    TIAA-CREF Mid-Cap Value Fund (Retirement):	TRVRX
-    TIAA-CREF Money Market Fund (Retirement):	TIEXX
-    TIAA-CREF Real Estate Securities Fund (Retirement):	TRRSX
-    TIAA-CREF S&P 500 Index Fund (Retirement):	TRSPX
-    TIAA-CREF Short-Term Bond Fund (Retirement):	TISRX
-    TIAA-CREF Small-Cap Blend Index Fund (Retirement):	TRBIX
-    TIAA-CREF Small-Cap Equity Fund (Retirement):	TRSEX
-    TIAA-CREF Social Choice Equity Fund (Retirement):	TRSCX
-    TIAA-CREF Bond Fund (Institutional):	TIBDX
-    TIAA-CREF Bond Index Fund (Institutional):	TBIIX
-    TIAA-CREF Bond Plus Fund (Institutional):	TIBFX
-    TIAA-CREF Emerging Markets Equity Fund (Institutional):	TEMLX
-    TIAA-CREF Emerging Markets Equity Index Fund (Institutional):	TEQLX
-    TIAA-CREF Enhanced International Equity Index Fund (Institutional):	TFIIX
-    TIAA-CREF Enhanced Large-Cap Growth Index Fund (Institutional):	TLIIX
-    TIAA-CREF Enhanced Large-Cap Value Index Fund (Institutional):	TEVIX
-    TIAA-CREF Equity Index Fund (Institutional):	TIEIX
-    TIAA-CREF Global Natural Resources Fund (Institutional):	TNRIX
-    TIAA-CREF Growth & Income Fund (Institutional):	TIGRX
-    TIAA-CREF High Yield Fund (Institutional):	TIHYX
-    TIAA-CREF Inflation-Linked Bond Fund (Institutional):	TIILX
-    TIAA-CREF International Equity Fund (Institutional):	TIIEX
-    TIAA-CREF International Equity Index Fund (Institutional):	TCIEX
-    TIAA-CREF Large-Cap Growth Fund (Institutional):	TILGX
-    TIAA-CREF Large-Cap Growth Index Fund (Institutional):	TILIX
-    TIAA-CREF Large-Cap Value Fund (Institutional):	TRLIX
-    TIAA-CREF Large-Cap Value Index Fund (Institutional):	TILVX
-    TIAA-CREF Lifecycle 2010 Fund (Institutional):	TCTIX
-    TIAA-CREF Lifecycle 2015 Fund (Institutional):	TCNIX
-    TIAA-CREF Lifecycle 2020 Fund (Institutional):	TCWIX
-    TIAA-CREF Lifecycle 2025 Fund (Institutional):	TCYIX
-    TIAA-CREF Lifecycle 2030 Fund (Institutional):	TCRIX
-    TIAA-CREF Lifecycle 2035 Fund (Institutional):	TCIIX
-    TIAA-CREF Lifecycle 2040 Fund (Institutional):	TCOIX
-    TIAA-CREF Lifecycle 2045 Fund (Institutional):	TTFIX
-    TIAA-CREF Lifecycle 2050 Fund (Institutional):	TFTIX
-    TIAA-CREF Lifecycle 2055 Fund (Institutional):	TTRIX
-    TIAA-CREF Lifecycle Index 2010 Fund (Institutional):	TLTIX
-    TIAA-CREF Lifecycle Index 2015 Fund (Institutional):	TLFIX
-    TIAA-CREF Lifecycle Index 2020 Fund (Institutional):	TLWIX
-    TIAA-CREF Lifecycle Index 2025 Fund (Institutional):	TLQIX
-    TIAA-CREF Lifecycle Index 2030 Fund (Institutional):	TLHIX
-    TIAA-CREF Lifecycle Index 2035 Fund (Institutional):	TLYIX
-    TIAA-CREF Lifecycle Index 2040 Fund (Institutional):	TLZIX
-    TIAA-CREF Lifecycle Index 2045 Fund (Institutional):	TLXIX
-    TIAA-CREF Lifecycle Index 2050 Fund (Institutional):	TLLIX
-    TIAA-CREF Lifecycle Index 2055 Fund (Institutional):	TTIIX
-    TIAA-CREF Lifecycle Index Retirement Income Fund (Institutional):	TRILX
-    TIAA-CREF Lifecycle Retirement Income Fund (Institutional):	TLRIX
-    TIAA-CREF Lifestyle Aggressive Growth Fund (Institutional):	TSAIX
-    TIAA-CREF Lifestyle Conservative Fund (Institutional):	TCSIX
-    TIAA-CREF Lifestyle Growth Fund (Institutional):	TSGGX
-    TIAA-CREF Lifestyle Income Fund (Institutional):	TSITX
-    TIAA-CREF Lifestyle Moderate Fund (Institutional):	TSIMX
-    TIAA-CREF Managed Allocation Fund (Institutional):	TIMIX
-    TIAA-CREF Mid-Cap Growth Fund (Institutional):	TRPWX
-    TIAA-CREF Mid-Cap Value Fund (Institutional):	TIMVX
-    TIAA-CREF Money Market Fund (Institutional):	TCIXX
-    TIAA-CREF Real Estate Securities Fund (Institutional):	TIREX
-    TIAA-CREF S&P 500 Index Fund (Institutional):	TISPX
-    TIAA-CREF Short-Term Bond Fund (Institutional):	TISIX
-    TIAA-CREF Small-Cap Blend Index Fund (Institutional):	TISBX
-    TIAA-CREF Small-Cap Equity Fund (Institutional):	TISEX
-    TIAA-CREF Social Choice Equity Fund (Institutional):	TISCX
-    TIAA-CREF Tax-Exempt Bond Fund (Institutional):	TITIX
-    TIAA-CREF Bond Fund (Retail):	TIORX
-    TIAA-CREF Bond Index Fund (Retail):	TBILX
-    TIAA-CREF Bond Plus Fund (Retail):	TCBPX
-    TIAA-CREF Emerging Markets Equity Fund (Retail):	TEMRX
-    TIAA-CREF Emerging Markets Equity Index Fund (Retail):	TEQKX
-    TIAA-CREF Equity Index Fund (Retail):	TINRX
-    TIAA-CREF Global Natural Resources Fund (Retail):	TNRLX
-    TIAA-CREF Growth & Income Fund (Retail):	TIIRX
-    TIAA-CREF High Yield Fund (Retail):	TIYRX
-    TIAA-CREF Inflation-Linked Bond Fund (Retail):	TCILX
-    TIAA-CREF International Equity Fund (Retail):	TIERX
-    TIAA-CREF Large-Cap Growth Fund (Retail):	TIRTX
-    TIAA-CREF Large-Cap Value Fund (Retail):	TCLCX
-    TIAA-CREF Lifecycle Retirement Income Fund (Retail):	TLRRX
-    TIAA-CREF Lifestyle Aggressive Growth Fund (Retail):	TSALX
-    TIAA-CREF Lifestyle Conservative Fund (Retail):	TSCLX
-    TIAA-CREF Lifestyle Growth Fund (Retail):	TSGLX
-    TIAA-CREF Lifestyle Income Fund (Retail):	TSILX
-    TIAA-CREF Lifestyle Moderate Fund (Retail):	TSMLX
-    TIAA-CREF Managed Allocation Fund (Retail):	TIMRX
-    TIAA-CREF Mid-Cap Growth Fund (Retail):	TCMGX
-    TIAA-CREF Mid-Cap Value Fund (Retail):	TCMVX
-    TIAA-CREF Money Market Fund (Retail):	TIRXX
-    TIAA-CREF Real Estate Securities Fund (Retail):	TCREX
-    TIAA-CREF Short-Term Bond Fund (Retail):	TCTRX
-    TIAA-CREF Small-Cap Equity Fund (Retail):	TCSEX
-    TIAA-CREF Social Choice Equity Fund (Retail):	TICRX
-    TIAA-CREF Tax-Exempt Bond Fund (Retail):	TIXRX
-    TIAA-CREF Bond Fund (Premier):	TIDPX
-    TIAA-CREF Bond Index Fund (Premier):	TBIPX
-    TIAA-CREF Bond Plus Fund (Premier):	TBPPX
-    TIAA-CREF Emerging Markets Equity Fund (Premier):	TEMPX
-    TIAA-CREF Emerging Markets Equity Index Fund (Premier):	TEQPX
-    TIAA-CREF Equity Index Fund (Premier):	TCEPX
-    TIAA-CREF Global Natural Resources Fund (Premier):	TNRPX
-    TIAA-CREF Growth & Income Fund (Premier):	TRPGX
-    TIAA-CREF High Yield Fund (Premier):	TIHPX
-    TIAA-CREF Inflation-Linked Bond Fund (Premier):	TIKPX
-    TIAA-CREF International Equity Fund (Premier):	TREPX
-    TIAA-CREF International Equity Index Fund (Premier):	TRIPX
-    TIAA-CREF Large-Cap Growth Fund (Premier):	TILPX
-    TIAA-CREF Large-Cap Value Fund (Premier):	TRCPX
-    TIAA-CREF Lifecycle 2010 Fund (Premier):	TCTPX
-    TIAA-CREF Lifecycle 2015 Fund (Premier):	TCFPX
-    TIAA-CREF Lifecycle 2020 Fund (Premier):	TCWPX
-    TIAA-CREF Lifecycle 2025 Fund (Premier):	TCQPX
-    TIAA-CREF Lifecycle 2030 Fund (Premier):	TCHPX
-    TIAA-CREF Lifecycle 2035 Fund (Premier):	TCYPX
-    TIAA-CREF Lifecycle 2040 Fund (Premier):	TCZPX
-    TIAA-CREF Lifecycle 2045 Fund (Premier):	TTFPX
-    TIAA-CREF Lifecycle 2050 Fund (Premier):	TCLPX
-    TIAA-CREF Lifecycle 2055 Fund (Premier):	TTRPX
-    TIAA-CREF Lifecycle Index 2010 Fund (Premier):	TLTPX
-    TIAA-CREF Lifecycle Index 2015 Fund (Premier):	TLFPX
-    TIAA-CREF Lifecycle Index 2020 Fund (Premier):	TLWPX
-    TIAA-CREF Lifecycle Index 2025 Fund (Premier):	TLVPX
-    TIAA-CREF Lifecycle Index 2030 Fund (Premier):	TLHPX
-    TIAA-CREF Lifecycle Index 2035 Fund (Premier):	TLYPX
-    TIAA-CREF Lifecycle Index 2040 Fund (Premier):	TLPRX
-    TIAA-CREF Lifecycle Index 2045 Fund (Premier):	TLMPX
-    TIAA-CREF Lifecycle Index 2050 Fund (Premier):	TLLPX
-    TIAA-CREF Lifecycle Index 2055 Fund (Premier):	TTIPX
-    TIAA-CREF Lifecycle Index Retirement Income Fund (Premier):	TLIPX
-    TIAA-CREF Lifecycle Retirement Income Fund (Premier):	TPILX
-    TIAA-CREF Lifestyle Aggressive Growth Fund (Premier):	TSAPX
-    TIAA-CREF Lifestyle Conservative Fund (Premier):	TLSPX
-    TIAA-CREF Lifestyle Growth Fund (Premier):	TSGPX
-    TIAA-CREF Lifestyle Income Fund (Premier):	TSIPX
-    TIAA-CREF Lifestyle Moderate Fund (Premier):	TSMPX
-    TIAA-CREF Mid-Cap Growth Fund (Premier):	TRGPX
-    TIAA-CREF Mid-Cap Value Fund (Premier):	TRVPX
-    TIAA-CREF Money Market Fund (Premier):	TPPXX
-    TIAA-CREF Real Estate Securities Fund (Premier):	TRRPX
-    TIAA-CREF Short-Term Bond Fund (Premier):	TSTPX
-    TIAA-CREF Small-Cap Equity Fund (Premier):	TSRPX
-    TIAA-CREF Social Choice Equity Fund (Premier):	TRPSX
-
 This module is loaded by default on a Finance::Quote object.  It's
 also possible to load it explicitly by passing "Tiaacref" in to the
-argument argument list of Finance::Quote->new().
+argument list of Finance::Quote->new().
 
-Information returned by this module is governed by TIAA-CREF's terms
+Information returned by this module is governed by TIAA's terms
 and conditions.
 
 =head1 LABELS RETURNED
@@ -1359,6 +323,6 @@ symbol, exchange, name, date, nav, price.
 
 =head1 SEE ALSO
 
-TIAA-CREF, http://www.tiaa-cref.org/
+TIAA, L<http://www.tiaa.org>
 
 =cut

--- a/t/tiaacref.t
+++ b/t/tiaacref.t
@@ -2,34 +2,55 @@
 use strict;
 use Test::More;
 use Finance::Quote;
+use Time::Piece;
 
 if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 45;
+plan tests => 91;
 
 # Test TIAA-CREF functions.
 
 my $q      = Finance::Quote->new();
-my $year   = (localtime())[5] + 1900;
+my $year   = localtime()->year;
 my $lastyear = $year - 1;
 
-my @symbols = qw / CREFmony TIAAreal TLSRX TCMVX TLGRX CREFbond /;
-my %quotes = $q->tiaacref(@symbols,"BOGOname");
-ok(%quotes,"quotes got retrieved");
+my @symbols = qw/
+    QCBMIX
+    TEMLX
+    TLFIX
+    TSBPX
+    W156#
+    W323#
+    W464#
+    W719#
+/;
 
-foreach my $symbol (@symbols) {
-    ok($quotes{$symbol,"success"} > 0,"$symbol got retrieved");
-    ok($quotes{$symbol,"nav"} > 0,"$symbol has a nav");
-    ok($quotes{$symbol, "currency"} eq "USD","$symbol currency is valid");
-    ok($quotes{$symbol,"price"} > 0,"$symbol price (".$quotes{$symbol,"price"}.")> 0");
-    ok(length($quotes{$symbol,"date"}) > 0,"$symbol has a valid date : ".$quotes{$symbol,"date"});
-    ok(substr($quotes{$symbol,"isodate"},0,4) == $year ||
-           substr($quotes{$symbol,"isodate"},0,4) == $lastyear,"$symbol isodate is recent");
-    ok(substr($quotes{$symbol,"date"},6,4) == $year ||
-           substr($quotes{$symbol,"date"},6,4) == $lastyear,"$symbol date is recent");
+ok( my %quotes = $q->tiaacref( @symbols, 'BOGUS' ), 'retrieved quotes' );
+
+for my $symbol (@symbols) {
+
+    # the following labels are expected to be supplied:
+    # symbol, nav, currency, method, exchange, price, date, isodate
+
+    ok( $quotes{$symbol,"success"} > 0,          "$symbol got retrieved"         );
+    ok( $quotes{$symbol,"symbol"} eq $symbol,    "$symbol has matching symbol"   );
+    ok( $quotes{$symbol,"nav"} > 0,              "$symbol has a NAV"             );
+    ok( $quotes{$symbol,"nav"} =~ /^[\d\.]+$/,   "$symbol NAV looks numeric"     );
+    ok( $quotes{$symbol,"currency"} eq "USD",    "$symbol currency is valid"     );
+    ok( $quotes{$symbol,"method"} eq 'tiaacref', "$symbol has matching method"   );
+    ok( $quotes{$symbol,"exchange"} eq 'TIAA',   "$symbol has matching exchange" );
+    ok( length $quotes{$symbol,"name"},          "$symbol has defined name"      );
+    ok( $quotes{$symbol,"price"} == $quotes{$symbol,'nav'},
+        "$symbol price == NAV" );
+    ok( substr($quotes{$symbol,"isodate"}, 0, 4) == $year
+     || substr($quotes{$symbol,"isodate"}, 0, 4) == $lastyear,
+        "$symbol isodate is recent" );
+    ok( substr($quotes{$symbol,"date"}, 6, 4) == $year
+     || substr($quotes{$symbol,"date"}, 6, 4) == $lastyear,
+        "$symbol date is recent" );
 };
 
-ok($quotes{"BOGOname","success"} == 0,"BOGUS failed");
-ok($quotes{"BOGOname","errormsg"} eq "Bad symbol","BOGUS returned errornsg");
+ok( $quotes{"BOGUS","success"} == 0,    "BOGUS failed" );
+ok( length $quotes{"BOGUS","errormsg"}, "BOGUS returned error message" );


### PR DESCRIPTION
Major re-write of the broken TIAA-CREF module. Greatly simplified method should be stable as long as the backing service URL remains functional. NOTE: some of these securities are available elsewhere and some are not.

Also, added a few testing dependencies that are used here and in other modules to `dist.ini`. They are now in core, but were not for very old perls which apparently are still supported by F::Q.