### PR TITLE
restore 'code' field in known_currencies()

### DIFF
--- a/lib/Finance/Quote/Currencies.pm
+++ b/lib/Finance/Quote/Currencies.pm
@@ -44,21 +44,25 @@ my %currencies = (
     'AED' => {
         'country' => ['UNITED ARAB EMIRATES (THE)'],
         'name'    => 'UAE Dirham',
+        'code'    => 'AED',
         'number'  => '784'
     },
     'AFN' => {
         'country' => ['AFGHANISTAN'],
         'name'    => 'Afghani',
+        'code'    => 'AFN',
         'number'  => '971'
     },
     'ALL' => {
         'country' => ['ALBANIA'],
         'name'    => 'Lek',
+        'code'    => 'ALL',
         'number'  => '008'
     },
     'AMD' => {
         'country' => ['ARMENIA'],
         'name'    => 'Armenian Dram',
+        'code'    => 'AMD',
         'number'  => '051'
     },
     'ANG' => {
@@ -67,16 +71,19 @@ my %currencies = (
             'SINT MAARTEN (DUTCH PART)'
         ],
         'name'    => 'Netherlands Antillean Guilder',
+        'code'    => 'ANG',
         'number'  => '532'
     },
     'AOA' => {
         'country' => ['ANGOLA'],
         'name'    => 'Kwanza',
+        'code'    => 'AOA',
         'number'  => '973'
     },
     'ARS' => {
         'country' => ['ARGENTINA'],
         'name'    => 'Argentine Peso',
+        'code'    => 'ARS',
         'number'  => '032'
     },
     'AUD' => {
@@ -91,111 +98,133 @@ my %currencies = (
             'TUVALU'
         ],
         'name'    => 'Australian Dollar',
+        'code'    => 'AUD',
         'number'  => '036'
     },
     'AWG' => {
         'country' => ['ARUBA'],
         'name'    => 'Aruban Florin',
+        'code'    => 'AWG',
         'number'  => '533'
     },
     'AZN' => {
         'country' => ['AZERBAIJAN'],
         'name'    => 'Azerbaijanian Manat',
+        'code'    => 'AZN',
         'number'  => '944'
     },
     'BAM' => {
         'country' => ['BOSNIA AND HERZEGOVINA'],
         'name'    => 'Convertible Mark',
+        'code'    => 'BAM',
         'number'  => '977'
     },
     'BBD' => {
         'country' => ['BARBADOS'],
         'name'    => 'Barbados Dollar',
+        'code'    => 'BBD',
         'number'  => '052'
     },
     'BDT' => {
         'country' => ['BANGLADESH'],
         'name'    => 'Taka',
+        'code'    => 'BDT',
         'number'  => '050'
     },
     'BGN' => {
         'country' => ['BULGARIA'],
         'name'    => 'Bulgarian Lev',
+        'code'    => 'BGN',
         'number'  => '975'
     },
     'BHD' => {
         'country' => ['BAHRAIN'],
         'name'    => 'Bahraini Dinar',
+        'code'    => 'BHD',
         'number'  => '048'
     },
     'BIF' => {
         'country' => ['BURUNDI'],
         'name'    => 'Burundi Franc',
+        'code'    => 'BIF',
         'number'  => '108'
     },
     'BMD' => {
         'country' => ['BERMUDA'],
         'name'    => 'Bermudian Dollar',
+        'code'    => 'BMD',
         'number'  => '060'
     },
     'BND' => {
         'country' => ['BRUNEI DARUSSALAM'],
         'name'    => 'Brunei Dollar',
+        'code'    => 'BND',
         'number'  => '096'
     },
     'BOB' => {
         'country' => ['BOLIVIA (PLURINATIONAL STATE OF)'],
         'name'    => 'Boliviano',
+        'code'    => 'BOB',
         'number'  => '068'
     },
     'BOV' => {
         'country' => ['BOLIVIA (PLURINATIONAL STATE OF)'],
         'name'    => 'Mvdol',
+        'code'    => 'BOV',
         'number'  => '984'
     },
     'BRL' => {
         'country' => ['BRAZIL'],
         'name'    => 'Brazilian Real',
+        'code'    => 'BRL',
         'number'  => '986'
     },
     'BSD' => {
         'country' => ['BAHAMAS (THE)'],
         'name'    => 'Bahamian Dollar',
+        'code'    => 'BSD',
         'number'  => '044'
     },
     'BTN' => {
         'country' => ['BHUTAN'],
         'name'    => 'Ngultrum',
+        'code'    => 'BTN',
         'number'  => '064'
     },
     'BWP' => {
         'country' => ['BOTSWANA'],
         'name'    => 'Pula',
+        'code'    => 'BWP',
         'number'  => '072'
     },
     'BYN' => {
         'country' => ['BELARUS'],
         'name'    => 'Belarussian Ruble',
+        'code'    => 'BYN',
         'number'  => '933'
     },
     'BZD' => {
         'country' => ['BELIZE'],
         'name'    => 'Belize Dollar',
+        'code'    => 'BZD',
         'number'  => '084'
     },
     'CAD' => {
         'country' => ['CANADA'],
         'name'    => 'Canadian Dollar',
+        'code'    => 'CAD',
         'number'  => '124'
     },
     'CDF' => {
         'country' => ['CONGO (THE DEMOCRATIC REPUBLIC OF THE)'],
         'name'    => 'Congolese Franc',
+        'code'    => 'CDF',
         'number'  => '976'
     },
     'CHE' => {
         'country' => ['SWITZERLAND'],
         'name'    => 'WIR Euro',
+        'code'    => 'CHE',
         'number'  => '947'
     },
     'CHF' => {
@@ -204,66 +233,79 @@ my %currencies = (
             'SWITZERLAND'
         ],
         'name'    => 'Swiss Franc',
+        'code'    => 'CHF',
         'number'  => '756'
     },
     'CHW' => {
         'country' => ['SWITZERLAND'],
         'name'    => 'WIR Franc',
+        'code'    => 'CHW',
         'number'  => '948'
     },
     'CLF' => {
         'country' => ['CHILE'],
         'name'    => 'Unidad de Fomento',
+        'code'    => 'CLF',
         'number'  => '990'
     },
     'CLP' => {
         'country' => ['CHILE'],
         'name'    => 'Chilean Peso',
+        'code'    => 'CLP',
         'number'  => '152'
     },
     'CNY' => {
         'country' => ['CHINA'],
         'name'    => 'Yuan Renminbi',
+        'code'    => 'CNY',
         'number'  => '156'
     },
     'COP' => {
         'country' => ['COLOMBIA'],
         'name'    => 'Colombian Peso',
+        'code'    => 'COP',
         'number'  => '170'
     },
     'COU' => {
         'country' => ['COLOMBIA'],
         'name'    => 'Unidad de Valor Real',
+        'code'    => 'COU',
         'number'  => '970'
     },
     'CRC' => {
         'country' => ['COSTA RICA'],
         'name'    => 'Costa Rican Colon',
+        'code'    => 'CRC',
         'number'  => '188'
     },
     'CUC' => {
         'country' => ['CUBA'],
         'name'    => 'Peso Convertible',
+        'code'    => 'CUC',
         'number'  => '931'
     },
     'CUP' => {
         'country' => ['CUBA'],
         'name'    => 'Cuban Peso',
+        'code'    => 'CUP',
         'number'  => '192'
     },
     'CVE' => {
         'country' => ['CABO VERDE'],
         'name'    => 'Cabo Verde Escudo',
+        'code'    => 'CVE',
         'number'  => '132'
     },
     'CZK' => {
         'country' => ['CZECH REPUBLIC (THE)'],
         'name'    => 'Czech Koruna',
+        'code'    => 'CZK',
         'number'  => '203'
     },
     'DJF' => {
         'country' => ['DJIBOUTI'],
         'name'    => 'Djibouti Franc',
+        'code'    => 'DJF',
         'number'  => '262'
     },
     'DKK' => {
@@ -273,31 +315,37 @@ my %currencies = (
             'GREENLAND'
         ],
         'name'    => 'Danish Krone',
+        'code'    => 'DKK',
         'number'  => '208'
     },
     'DOP' => {
         'country' => ['DOMINICAN REPUBLIC (THE)'],
         'name'    => 'Dominican Peso',
+        'code'    => 'DOP',
         'number'  => '214'
     },
     'DZD' => {
         'country' => ['ALGERIA'],
         'name'    => 'Algerian Dinar',
+        'code'    => 'DZD',
         'number'  => '012'
     },
     'EGP' => {
         'country' => ['EGYPT'],
         'name'    => 'Egyptian Pound',
+        'code'    => 'EGP',
         'number'  => '818'
     },
     'ERN' => {
         'country' => ['ERITREA'],
         'name'    => 'Nakfa',
+        'code'    => 'ERN',
         'number'  => '232'
     },
     'ETB' => {
         'country' => ['ETHIOPIA'],
         'name'    => 'Ethiopian Birr',
+        'code'    => 'ETB',
         'number'  => '230'
     },
     'EUR' => {
@@ -339,16 +387,19 @@ my %currencies = (
             'SPAIN'
         ],
         'name'    => 'Euro',
+        'code'    => 'EUR',
         'number'  => '978'
     },
     'FJD' => {
         'country' => ['FIJI'],
         'name'    => 'Fiji Dollar',
+        'code'    => 'FJD',
         'number'  => '242'
     },
     'FKP' => {
         'country' => ['FALKLAND ISLANDS (THE) [MALVINAS]'],
         'name'    => 'Falkland Islands Pound',
+        'code'    => 'FKP',
         'number'  => '238'
     },
     'GBP' => {
@@ -359,76 +410,91 @@ my %currencies = (
             'UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND (THE)'
         ],
         'name'    => 'Pound Sterling',
+        'code'    => 'GBP',
         'number'  => '826'
     },
     'GEL' => {
         'country' => ['GEORGIA'],
         'name'    => 'Lari',
+        'code'    => 'GEL',
         'number'  => '981'
     },
     'GHS' => {
         'country' => ['GHANA'],
         'name'    => 'Ghana Cedi',
+        'code'    => 'GHS',
         'number'  => '936'
     },
     'GIP' => {
         'country' => ['GIBRALTAR'],
         'name'    => 'Gibraltar Pound',
+        'code'    => 'GIP',
         'number'  => '292'
     },
     'GMD' => {
         'country' => ['GAMBIA (THE)'],
         'name'    => 'Dalasi',
+        'code'    => 'GMD',
         'number'  => '270'
     },
     'GNF' => {
         'country' => ['GUINEA'],
         'name'    => 'Guinea Franc',
+        'code'    => 'GNF',
         'number'  => '324'
     },
     'GTQ' => {
         'country' => ['GUATEMALA'],
         'name'    => 'Quetzal',
+        'code'    => 'GTQ',
         'number'  => '320'
     },
     'GYD' => {
         'country' => ['GUYANA'],
         'name'    => 'Guyana Dollar',
+        'code'    => 'GYD',
         'number'  => '328'
     },
     'HKD' => {
         'country' => ['HONG KONG'],
         'name'    => 'Hong Kong Dollar',
+        'code'    => 'HKD',
         'number'  => '344'
     },
     'HNL' => {
         'country' => ['HONDURAS'],
         'name'    => 'Lempira',
+        'code'    => 'HNL',
         'number'  => '340'
     },
     'HRK' => {
         'country' => ['CROATIA'],
         'name'    => 'Kuna',
+        'code'    => 'HRK',
         'number'  => '191'
     },
     'HTG' => {
         'country' => ['HAITI'],
         'name'    => 'Gourde',
+        'code'    => 'HTG',
         'number'  => '332'
     },
     'HUF' => {
         'country' => ['HUNGARY'],
         'name'    => 'Forint',
+        'code'    => 'HUF',
         'number'  => '348'
     },
     'IDR' => {
         'country' => ['INDONESIA'],
         'name'    => 'Rupiah',
+        'code'    => 'IDR',
         'number'  => '360'
     },
     'ILS' => {
         'country' => ['ISRAEL'],
         'name'    => 'New Israeli Sheqel',
+        'code'    => 'ILS',
         'number'  => '376'
     },
     'INR' => {
@@ -437,111 +503,133 @@ my %currencies = (
             'INDIA'
         ],
         'name'    => 'Indian Rupee',
+        'code'    => 'INR',
         'number'  => '356'
     },
     'IQD' => {
         'country' => ['IRAQ'],
         'name'    => 'Iraqi Dinar',
+        'code'    => 'IQD',
         'number'  => '368'
     },
     'IRR' => {
         'country' => ['IRAN (ISLAMIC REPUBLIC OF)'],
         'name'    => 'Iranian Rial',
+        'code'    => 'IRR',
         'number'  => '364'
     },
     'ISK' => {
         'country' => ['ICELAND'],
         'name'    => 'Iceland Krona',
+        'code'    => 'ISK',
         'number'  => '352'
     },
     'JMD' => {
         'country' => ['JAMAICA'],
         'name'    => 'Jamaican Dollar',
+        'code'    => 'JMD',
         'number'  => '388'
     },
     'JOD' => {
         'country' => ['JORDAN'],
         'name'    => 'Jordanian Dinar',
+        'code'    => 'JOD',
         'number'  => '400'
     },
     'JPY' => {
         'country' => ['JAPAN'],
         'name'    => 'Yen',
+        'code'    => 'JPY',
         'number'  => '392'
     },
     'KES' => {
         'country' => ['KENYA'],
         'name'    => 'Kenyan Shilling',
+        'code'    => 'KES',
         'number'  => '404'
     },
     'KGS' => {
         'country' => ['KYRGYZSTAN'],
         'name'    => 'Som',
+        'code'    => 'KGS',
         'number'  => '417'
     },
     'KHR' => {
         'country' => ['CAMBODIA'],
         'name'    => 'Riel',
+        'code'    => 'KHR',
         'number'  => '116'
     },
     'KMF' => {
         'country' => ['COMOROS (THE)'],
         'name'    => 'Comoro Franc',
+        'code'    => 'KMF',
         'number'  => '174'
     },
     'KPW' => {
         'country' => ['KOREA (THE DEMOCRATIC PEOPLE’S REPUBLIC OF)'],
         'name'    => 'North Korean Won',
+        'code'    => 'KPW',
         'number'  => '408'
     },
     'KRW' => {
         'country' => ['KOREA (THE REPUBLIC OF)'],
         'name'    => 'Won',
+        'code'    => 'KRW',
         'number'  => '410'
     },
     'KWD' => {
         'country' => ['KUWAIT'],
         'name'    => 'Kuwaiti Dinar',
+        'code'    => 'KWD',
         'number'  => '414'
     },
     'KYD' => {
         'country' => ['CAYMAN ISLANDS (THE)'],
         'name'    => 'Cayman Islands Dollar',
+        'code'    => 'KYD',
         'number'  => '136'
     },
     'KZT' => {
         'country' => ['KAZAKHSTAN'],
         'name'    => 'Tenge',
+        'code'    => 'KZT',
         'number'  => '398'
     },
     'LAK' => {
         'country' => ['LAO PEOPLE’S DEMOCRATIC REPUBLIC (THE)'],
         'name'    => 'Kip',
+        'code'    => 'LAK',
         'number'  => '418'
     },
     'LBP' => {
         'country' => ['LEBANON'],
         'name'    => 'Lebanese Pound',
+        'code'    => 'LBP',
         'number'  => '422'
     },
     'LKR' => {
         'country' => ['SRI LANKA'],
         'name'    => 'Sri Lanka Rupee',
+        'code'    => 'LKR',
         'number'  => '144'
     },
     'LRD' => {
         'country' => ['LIBERIA'],
         'name'    => 'Liberian Dollar',
+        'code'    => 'LRD',
         'number'  => '430'
     },
     'LSL' => {
         'country' => ['LESOTHO'],
         'name'    => 'Loti',
+        'code'    => 'LSL',
         'number'  => '426'
     },
     'LYD' => {
         'country' => ['LIBYA'],
         'name'    => 'Libyan Dinar',
+        'code'    => 'LYD',
         'number'  => '434'
     },
     'MAD' => {
@@ -550,91 +638,109 @@ my %currencies = (
             'WESTERN SAHARA'
         ],
         'name'    => 'Moroccan Dirham',
+        'code'    => 'MAD',
         'number'  => '504'
     },
     'MDL' => {
         'country' => ['MOLDOVA (THE REPUBLIC OF)'],
         'name'    => 'Moldovan Leu',
+        'code'    => 'MDL',
         'number'  => '498'
     },
     'MGA' => {
         'country' => ['MADAGASCAR'],
         'name'    => 'Malagasy Ariary',
+        'code'    => 'MGA',
         'number'  => '969'
     },
     'MKD' => {
         'country' => ['REPUBLIC OF NORTH MACEDONIA'],
         'name'    => 'Denar',
+        'code'    => 'MKD',
         'number'  => '807'
     },
     'MMK' => {
         'country' => ['MYANMAR'],
         'name'    => 'Kyat',
+        'code'    => 'MMK',
         'number'  => '104'
     },
     'MNT' => {
         'country' => ['MONGOLIA'],
         'name'    => 'Tugrik',
+        'code'    => 'MNT',
         'number'  => '496'
     },
     'MOP' => {
         'country' => ['MACAO'],
         'name'    => 'Pataca',
+        'code'    => 'MOP',
         'number'  => '446'
     },
     'MRU' => {
         'country' => ['MAURITANIA'],
         'name'    => 'Ouguiya',
+        'code'    => 'MRU',
         'number'  => '929'
     },
     'MUR' => {
         'country' => ['MAURITIUS'],
         'name'    => 'Mauritius Rupee',
+        'code'    => 'MUR',
         'number'  => '480'
     },
     'MVR' => {
         'country' => ['MALDIVES'],
         'name'    => 'Rufiyaa',
+        'code'    => 'MVR',
         'number'  => '462'
     },
     'MWK' => {
         'country' => ['MALAWI'],
         'name'    => 'Kwacha',
+        'code'    => 'MWK',
         'number'  => '454'
     },
     'MXN' => {
         'country' => ['MEXICO'],
         'name'    => 'Mexican Peso',
+        'code'    => 'MXN',
         'number'  => '484'
     },
     'MXV' => {
         'country' => ['MEXICO'],
         'name'    => 'Mexican Unidad de Inversion (UDI)',
+        'code'    => 'MXV',
         'number'  => '979'
     },
     'MYR' => {
         'country' => ['MALAYSIA'],
         'name'    => 'Malaysian Ringgit',
+        'code'    => 'MYR',
         'number'  => '458'
     },
     'MZN' => {
         'country' => ['MOZAMBIQUE'],
         'name'    => 'Mozambique Metical',
+        'code'    => 'MZN',
         'number'  => '943'
     },
     'NAD' => {
         'country' => ['NAMIBIA'],
         'name'    => 'Namibia Dollar',
+        'code'    => 'NAD',
         'number'  => '516'
     },
     'NGN' => {
         'country' => ['NIGERIA'],
         'name'    => 'Naira',
+        'code'    => 'NGN',
         'number'  => '566'
     },
     'NIO' => {
         'country' => ['NICARAGUA'],
         'name'    => 'Cordoba Oro',
+        'code'    => 'NIO',
         'number'  => '558'
     },
     'NOK' => {
@@ -644,11 +750,13 @@ my %currencies = (
             'SVALBARD AND JAN MAYEN'
         ],
         'name'    => 'Norwegian Krone',
+        'code'    => 'NOK',
         'number'  => '578'
     },
     'NPR' => {
         'country' => ['NEPAL'],
         'name'    => 'Nepalese Rupee',
+        'code'    => 'NPR',
         'number'  => '524'
     },
     'NZD' => {
@@ -660,201 +768,241 @@ my %currencies = (
             'TOKELAU'
         ],
         'name'    => 'New Zealand Dollar',
+        'code'    => 'NZD',
         'number'  => '554'
     },
     'OMR' => {
         'country' => ['OMAN'],
         'name'    => 'Rial Omani',
+        'code'    => 'OMR',
         'number'  => '512'
     },
     'PAB' => {
         'country' => ['PANAMA'],
         'name'    => 'Balboa',
+        'code'    => 'PAB',
         'number'  => '590'
     },
     'PEN' => {
         'country' => ['PERU'],
         'name'    => 'Nuevo Sol',
+        'code'    => 'PEN',
         'number'  => '604'
     },
     'PGK' => {
         'country' => ['PAPUA NEW GUINEA'],
         'name'    => 'Kina',
+        'code'    => 'PGK',
         'number'  => '598'
     },
     'PHP' => {
         'country' => ['PHILIPPINES (THE)'],
         'name'    => 'Philippine Peso',
+        'code'    => 'PHP',
         'number'  => '608'
     },
     'PKR' => {
         'country' => ['PAKISTAN'],
         'name'    => 'Pakistan Rupee',
+        'code'    => 'PKR',
         'number'  => '586'
     },
     'PLN' => {
         'country' => ['POLAND'],
         'name'    => 'Zloty',
+        'code'    => 'PLN',
         'number'  => '985'
     },
     'PYG' => {
         'country' => ['PARAGUAY'],
         'name'    => 'Guarani',
+        'code'    => 'PYG',
         'number'  => '600'
     },
     'QAR' => {
         'country' => ['QATAR'],
         'name'    => 'Qatari Rial',
+        'code'    => 'QAR',
         'number'  => '634'
     },
     'RON' => {
         'country' => ['ROMANIA'],
         'name'    => 'Romanian Leu',
+        'code'    => 'RON',
         'number'  => '946'
     },
     'RSD' => {
         'country' => ['SERBIA'],
         'name'    => 'Serbian Dinar',
+        'code'    => 'RSD',
         'number'  => '941'
     },
     'RUB' => {
         'country' => ['RUSSIAN FEDERATION (THE)'],
         'name'    => 'Russian Ruble',
+        'code'    => 'RUB',
         'number'  => '643'
     },
     'RWF' => {
         'country' => ['RWANDA'],
         'name'    => 'Rwanda Franc',
+        'code'    => 'RWF',
         'number'  => '646'
     },
     'SAR' => {
         'country' => ['SAUDI ARABIA'],
         'name'    => 'Saudi Riyal',
+        'code'    => 'SAR',
         'number'  => '682'
     },
     'SBD' => {
         'country' => ['SOLOMON ISLANDS'],
         'name'    => 'Solomon Islands Dollar',
+        'code'    => 'SBD',
         'number'  => '090'
     },
     'SCR' => {
         'country' => ['SEYCHELLES'],
         'name'    => 'Seychelles Rupee',
+        'code'    => 'SCR',
         'number'  => '690'
     },
     'SDG' => {
         'country' => ['SUDAN (THE)'],
         'name'    => 'Sudanese Pound',
+        'code'    => 'SDG',
         'number'  => '938'
     },
     'SEK' => {
         'country' => ['SWEDEN'],
         'name'    => 'Swedish Krona',
+        'code'    => 'SEK',
         'number'  => '752'
     },
     'SGD' => {
         'country' => ['SINGAPORE'],
         'name'    => 'Singapore Dollar',
+        'code'    => 'SGD',
         'number'  => '702'
     },
     'SHP' => {
         'country' => ['SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA'],
         'name'    => 'Saint Helena Pound',
+        'code'    => 'SHP',
         'number'  => '654'
     },
     'SLL' => {
         'country' => ['SIERRA LEONE'],
         'name'    => 'Leone',
+        'code'    => 'SLL',
         'number'  => '694'
     },
     'SOS' => {
         'country' => ['SOMALIA'],
         'name'    => 'Somali Shilling',
+        'code'    => 'SOS',
         'number'  => '706'
     },
     'SRD' => {
         'country' => ['SURINAME'],
         'name'    => 'Surinam Dollar',
+        'code'    => 'SRD',
         'number'  => '968'
     },
     'SSP' => {
         'country' => ['SOUTH SUDAN'],
         'name'    => 'South Sudanese Pound',
+        'code'    => 'SSP',
         'number'  => '728'
     },
     'STN' => {
         'country' => ['SAO TOME AND PRINCIPE'],
         'name'    => 'Dobra',
+        'code'    => 'STN',
         'number'  => '930'
     },
     'SVC' => {
         'country' => ['EL SALVADOR'],
         'name'    => 'El Salvador Colon',
+        'code'    => 'SVC',
         'number'  => '222'
     },
     'SYP' => {
         'country' => ['SYRIAN ARAB REPUBLIC'],
         'name'    => 'Syrian Pound',
+        'code'    => 'SYP',
         'number'  => '760'
     },
     'SZL' => {
         'country' => ['SWAZILAND'],
         'name'    => 'Lilangeni',
+        'code'    => 'SZL',
         'number'  => '748'
     },
     'THB' => {
         'country' => ['THAILAND'],
         'name'    => 'Baht',
+        'code'    => 'THB',
         'number'  => '764'
     },
     'TJS' => {
         'country' => ['TAJIKISTAN'],
         'name'    => 'Somoni',
+        'code'    => 'TJS',
         'number'  => '972'
     },
     'TMT' => {
         'country' => ['TURKMENISTAN'],
         'name'    => 'Turkmenistan New Manat',
+        'code'    => 'TMT',
         'number'  => '934'
     },
     'TND' => {
         'country' => ['TUNISIA'],
         'name'    => 'Tunisian Dinar',
+        'code'    => 'TND',
         'number'  => '788'
     },
     'TOP' => {
         'country' => ['TONGA'],
         'name'    => 'Pa’anga',
+        'code'    => 'TOP',
         'number'  => '776'
     },
     'TRY' => {
         'country' => ['TURKEY'],
         'name'    => 'Turkish Lira',
+        'code'    => 'TRY',
         'number'  => '949'
     },
     'TTD' => {
         'country' => ['TRINIDAD AND TOBAGO'],
         'name'    => 'Trinidad and Tobago Dollar',
+        'code'    => 'TTD',
         'number'  => '780'
     },
     'TWD' => {
         'country' => ['TAIWAN (PROVINCE OF CHINA)'],
         'name'    => 'New Taiwan Dollar',
+        'code'    => 'TWD',
         'number'  => '901'
     },
     'TZS' => {
         'country' => ['TANZANIA, UNITED REPUBLIC OF'],
         'name'    => 'Tanzanian Shilling',
+        'code'    => 'TZS',
         'number'  => '834'
     },
     'UAH' => {
         'country' => ['UKRAINE'],
         'name'    => 'Hryvnia',
+        'code'    => 'UAH',
         'number'  => '980'
     },
     'UGX' => {
         'country' => ['UGANDA'],
         'name'    => 'Uganda Shilling',
+        'code'    => 'UGX',
         'number'  => '800'
     },
     'USD' => {
@@ -880,46 +1028,55 @@ my %currencies = (
             'VIRGIN ISLANDS (U.S.)'
         ],
         'name'    => 'US Dollar',
+        'code'    => 'USD',
         'number'  => '840'
     },
     'USN' => {
         'country' => ['UNITED STATES OF AMERICA (THE)'],
         'name'    => 'US Dollar (Next day)',
+        'code'    => 'USN',
         'number'  => '997'
     },
     'UYI' => {
         'country' => ['URUGUAY'],
         'name'    => 'Uruguay Peso en Unidades Indexadas (URUIURUI)',
+        'code'    => 'UYI',
         'number'  => '940'
     },
     'UYU' => {
         'country' => ['URUGUAY'],
         'name'    => 'Peso Uruguayo',
+        'code'    => 'UYU',
         'number'  => '858'
     },
     'UZS' => {
         'country' => ['UZBEKISTAN'],
         'name'    => 'Uzbekistan Sum',
+        'code'    => 'UZS',
         'number'  => '860'
     },
     'VEF' => {
         'country' => ['VENEZUELA (BOLIVARIAN REPUBLIC OF)'],
         'name'    => 'Bolivar',
+        'code'    => 'VEF',
         'number'  => '937'
     },
     'VND' => {
         'country' => ['VIET NAM'],
         'name'    => 'Dong',
+        'code'    => 'VND',
         'number'  => '704'
     },
     'VUV' => {
         'country' => ['VANUATU'],
         'name'    => 'Vatu',
+        'code'    => 'VUV',
         'number'  => '548'
     },
     'WST' => {
         'country' => ['SAMOA'],
         'name'    => 'Tala',
+        'code'    => 'WST',
         'number'  => '882'
     },
     'XAF' => {
@@ -932,6 +1089,7 @@ my %currencies = (
             'GABON'
         ],
         'name'    => 'CFA Franc BEAC',
+        'code'    => 'XAF',
         'number'  => '950'
     },
     'XCD' => {
@@ -946,11 +1104,13 @@ my %currencies = (
             'SAINT VINCENT AND THE GRENADINES'
         ],
         'name'    => 'East Caribbean Dollar',
+        'code'    => 'XCD',
         'number'  => '951'
     },
     'XDR' => {
         'country' => ['INTERNATIONAL MONETARY FUND (IMF) '],
         'name'    => 'SDR (Special Drawing Right)',
+        'code'    => 'XDR',
         'number'  => '960'
     },
     'XOF' => {
@@ -965,6 +1125,7 @@ my %currencies = (
             'TOGO'
         ],
         'name'    => 'CFA Franc BCEAO',
+        'code'    => 'XOF',
         'number'  => '952'
     },
     'XPF' => {
@@ -974,21 +1135,25 @@ my %currencies = (
             'WALLIS AND FUTUNA'
         ],
         'name'    => 'CFP Franc',
+        'code'    => 'XPF',
         'number'  => '953'
     },
     'XSU' => {
         'country' => ['SISTEMA UNITARIO DE COMPENSACION REGIONAL DE PAGOS "SUCRE"'],
         'name'    => 'Sucre',
+        'code'    => 'XSU',
         'number'  => '994'
     },
     'XUA' => {
         'country' => ['MEMBER COUNTRIES OF THE AFRICAN DEVELOPMENT BANK GROUP'],
         'name'    => 'ADB Unit of Account',
+        'code'    => 'XUA',
         'number'  => '965'
     },
     'YER' => {
         'country' => ['YEMEN'],
         'name'    => 'Yemeni Rial',
+        'code'    => 'YER',
         'number'  => '886'
     },
     'ZAR' => {
@@ -998,16 +1163,19 @@ my %currencies = (
             'SOUTH AFRICA'
         ],
         'name'    => 'Rand',
+        'code'    => 'ZAR',
         'number'  => '710'
     },
     'ZMW' => {
         'country' => ['ZAMBIA'],
         'name'    => 'Zambian Kwacha',
+        'code'    => 'ZMW',
         'number'  => '967'
     },
     'ZWL' => {
         'country' => ['ZIMBABWE'],
         'name'    => 'Zimbabwe Dollar',
+        'code'    => 'ZWL',
         'number'  => '932'
     },
 
@@ -1052,6 +1220,7 @@ sub fetch_live_currencies {
     else {
       $result{$code} = {'name'    => $currency,
                         'country' => [$country],
+                        'code'    => $code,
                         'number'  => $number};
     }
   }
@@ -1096,8 +1265,8 @@ Both functions return a hash
 
 =head1 CACHE DATE
 
-The currency list stored in this module was last copied from the live site July
-2019.
+The currency list stored in this module was last copied from the live site Oct
+2020.
 
 =head1 LICENSE
 


### PR DESCRIPTION
I noticed in separate failed PR that the `currency_lookup.t` test unit is now failing, and I think it was due to an earlier PR of mine. Apparently the last fix to `Currencies.pm` fixed one bug but broke expected behavior that was used elsewhere (in Quote.pm `currency_lookup()`). This commit restores the 'code' field so that both 'code' and 'number' are available and `currency_lookup.t` passes.