### PR TITLE
guard another test with $ENV{'ONLINE_TEST'}

### DIFF
--- a/t/fq-object-methods.t
+++ b/t/fq-object-methods.t
@@ -2,6 +2,10 @@
 use strict;
 use Test::More;
 
+if (not $ENV{'ONLINE_TEST'}) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
 plan tests => 23;
 
 use Finance::Quote;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Finance-Quote.
We thought you might be interested in it too.

    Description: guard another test with $ENV{'ONLINE_TEST'}
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2021-03-06
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libfinance-quote-perl/raw/master/debian/patches/online.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
