### PR TITLE
Fix some spelling mistakes

### DIFF
--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -1246,7 +1246,7 @@ to new() enables the caller to provide a configuration HASH to the corresponding
 method.
 
 The key 'currency_rates' configures the Finanace::Quote currency rate
-conversion.  By default, to maintain backward compatability,
+conversion.  By default, to maintain backward compatibility,
 Finance::Quote::CurrencyRates::AlphaVantage is used for currency conversion.
 This end point requires an API key, which can either be set in the environment
 or included in the configuration hash. To specify a different primary currency
@@ -1356,7 +1356,7 @@ performance, currency conversion rates are cached and are assumed not to change
 for the duration of the Finance::Quote object.
 
 See the introduction to this page for information on how to configure the
-souce of currency conversion rates.
+source of currency conversion rates.
 
 =head2 get_required_labels
 
@@ -1383,7 +1383,7 @@ web requests.
 
     $q->set_timeout(45);
 
-C<set_timeout> updated teh timeout in seconds for the quoter object.
+C<set_timeout> updated the timeout in seconds for the quoter object.
 
 =head2 store_date
 
@@ -1456,7 +1456,7 @@ constraint.
 
     my @list = Finance::Quote::parse_csv($string);
 
-C<parse_csv> is a utility function for spliting a comma seperated value string
+C<parse_csv> is a utility function for splitting a comma separated value string
 into a list of terms, treating double-quoted strings that contain commas as a
 single value.
 
@@ -1464,7 +1464,7 @@ single value.
 
     my @list = Finance::Quote::parse_csv_semicolon($string);
 
-C<parse_csv> is a utility function for spliting a semicolon seperated value string
+C<parse_csv> is a utility function for splitting a semicolon separated value string
 into a list of terms, treating double-quoted strings that contain semicolons as a
 single value.
 

--- a/lib/Finance/Quote/AEX.pm
+++ b/lib/Finance/Quote/AEX.pm
@@ -178,7 +178,7 @@ Finance::Quote::AEX - Obtain quotes from Amsterdam Euronext eXchange
 
 =head1 DESCRIPTION
 
-Thie module fetches information from https://live.euronext.com.  Stocks and bonds
+This module fetches information from https://live.euronext.com.  Stocks and bonds
 are supported.
 
 This module is loaded by default on a Finance::Quote object. It's also possible

--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -319,7 +319,7 @@ Finance::Quote::AlphaVantage - Obtain quotes from https://iexcloud.io
 This module fetches information from https://www.alphavantage.co.
 
 This module is loaded by default on a Finance::Quote object. It's also possible
-to load it explicity by placing "AlphaVantage" in the argument list to
+to load it explicitly by placing "AlphaVantage" in the argument list to
 Finance::Quote->new().
 
 This module provides the "alphavantage" fetch method.

--- a/lib/Finance/Quote/CurrencyRates/Fixer.pm
+++ b/lib/Finance/Quote/CurrencyRates/Fixer.pm
@@ -103,7 +103,7 @@ This module fetches currency rates from https://fixer.io and provides data to
 Finance::Quote to convert the first argument to the equivalent value in the
 currency indicated by the second argument.
 
-Thie module caches the currency rates for the lifetime of the quoter object,
+This module caches the currency rates for the lifetime of the quoter object,
 unless 'cache => 0' is included in the 'fixer' options hash.
 
 =head1 API_KEY

--- a/lib/Finance/Quote/CurrencyRates/OpenExchange.pm
+++ b/lib/Finance/Quote/CurrencyRates/OpenExchange.pm
@@ -104,7 +104,7 @@ This module fetches currency rates from https://openexchangerates.org and
 provides data to Finance::Quote to convert the first argument to the equivalent
 value in the currency indicated by the second argument.
 
-Thie module caches the currency rates for the lifetime of the quoter object,
+This module caches the currency rates for the lifetime of the quoter object,
 unless 'cache => 0' is included in the 'openexchange' options hash.
 
 =head1 API_KEY

--- a/lib/Finance/Quote/IEXCloud.pm
+++ b/lib/Finance/Quote/IEXCloud.pm
@@ -127,7 +127,7 @@ Finance::Quote::IEXClound - Obtain quotes from https://iexcloud.io
 This module fetches information from https://iexcloud.io.
 
 This module is loaded by default on a Finance::Quote object. It's
-also possible to load it explicity by placing "IEXCloud" in the argument
+also possible to load it explicitly by placing "IEXCloud" in the argument
 list to Finance::Quote->new().
 
 This module provides the "iexcloud" fetch method.

--- a/lib/Finance/Quote/OnVista.pm
+++ b/lib/Finance/Quote/OnVista.pm
@@ -196,7 +196,7 @@ Finance::Quote::OnVista Obtain quotes from OnVista.
 This module fetches information from OnVista, https://www.onvista.de. All stocks are available.
 
 This module is loaded by default on a Finance::Quote object. It's
-also possible to load it explicity by placing "onvista" in the argument
+also possible to load it explicitly by placing "onvista" in the argument
 list to Finance::Quote->new().
 
 Information obtained by this module may be covered by www.onvista.de


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Finance-Quote.
We thought you might be interested in it too.

    Description: Fix some spelling mistakes
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2021-03-07
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libfinance-quote-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
