### PR TITLE
Add TRT suffix to AlphaVantage

### DIFF
--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -59,6 +59,7 @@ my %currencies_by_suffix = (
     '.BR'  => "EUR",    # Belgium		Brussels
     '.TO'  => "CAD",    # Canada		Toronto
     '.V'   => "CAD",    # 		Toronto Venture
+	'.TRT' => "CAD",    # Canada        Toronto
     '.SN'  => "CLP",    # Chile		Santiago
     '.SS'  => "CNY",    # China		Shanghai
     '.SZ'  => "CNY",    # 		Shenzhen

--- a/t/alphavantage.t
+++ b/t/alphavantage.t
@@ -40,6 +40,7 @@ my @symbols =  qw/
     F
     AXP
     ERCB.DE
+	MRT-UN.TRT
 /;
 
 plan tests => 11*(1+$#symbols)+10;
@@ -69,6 +70,7 @@ is( $quotes{ "ERCB.DE", "currency" }, 'EUR' );
 is( $quotes{ "SOLB.BR", "currency" }, 'EUR' );
 is( $quotes{ "SAP.DE", "currency" }, 'EUR' );
 is( $quotes{ "TD.TO", "currency" }, 'CAD' );
+is( $quotes{ "MRT-UN.TRT", "currency" }, 'CAD' );
 is( $quotes{ "LSE.L", "currency" }, 'GBP' );
 is( $quotes{ "DIVO11.SA", "currency" }, 'BRL' );
 

--- a/t/alphavantage.t
+++ b/t/alphavantage.t
@@ -43,7 +43,7 @@ my @symbols =  qw/
 	MRT-UN.TRT
 /;
 
-plan tests => 11*(1+$#symbols)+10;
+plan tests => 11*(1+$#symbols)+11;
 
 my %quotes = $q->alphavantage( @symbols, "BOGUS" );
 ok(%quotes);


### PR DESCRIPTION
When using online quotes in GnuCash, Toronto Stock Exchange prices for stocks like
MRT-UN.TO, HOT-UN.TO, CUF-UN.TO, PLZ-UN.TO, BPF-UN.TO are not being
populated.
This happens because in AlphaVantage these stocks are represented with
the TRT suffix (e.g. MRT-UN.TRT instead of MRT-UN.TO).
Even if MRT-UN.TRT is used as stock symbol the prices are still not populated in GnuCash because AlphaVantage.pm 
doesn't know about the TRT suffix. 
This pull request adds the TRT suffix and associates CAD to it.