### PR TITLE
Suppress expected warning message in FQ test.  Resolves #189.

### DIFF
--- a/t/currency_lookup.t
+++ b/t/currency_lookup.t
@@ -48,6 +48,9 @@ cmp_ok( scalar keys %{$currencies}
       , "Empty hashref returned for non-matching lookup"
       );
 
+# Suppress warning message in last test
+local $SIG{__WARN__} = sub {};
+
 # Test that an error returns undef
 $currencies = Finance::Quote::currency_lookup( invalid_param => 1 );
 is( $currencies


### PR DESCRIPTION
The warning message highlighted in issue #189 is expected because it is testing an invalid parameter.  Added WARN signal handler in test file to hide the message in the the test output.