### PR TITLE
Changed $symbol to $stock in calls to store_date

### DIFF
--- a/lib/Finance/Quote/Bourso.pm
+++ b/lib/Finance/Quote/Bourso.pm
@@ -162,10 +162,10 @@ sub bourso {
           $info{$stock, 'net'}      = $net if $net;
 
           # 2020-07-17 17:03:45
-          $quoter->store_date(\%info, $symbol, {isodate => $1}) if $date =~ m|([0-9]{4}-[0-9]{2}-[0-9]{2})|;
+          $quoter->store_date(\%info, $stock, {isodate => $1}) if $date =~ m|([0-9]{4}-[0-9]{2}-[0-9]{2})|;
 
           # dd/mm/yyyy
-          $quoter->store_date(\%info, $symbol, {eurodate => $1}) if $date =~ m|([0-9]{2}/[0-9]{2}/[0-9]{4})|;
+          $quoter->store_date(\%info, $stock, {eurodate => $1}) if $date =~ m|([0-9]{2}/[0-9]{2}/[0-9]{4})|;
 
           $info{$stock, 'method' } = 'bourso'; 
           $info{$stock, 'success'} = 1;


### PR DESCRIPTION
Fix for issue #174. The symbol derived from parsing the HTML retrieved for some securities does not match the stock requested. Calling the store_date method with the symbol instead of $stock does not populate the correct hash.