### PR TITLE
Added new module TesouroDireto.pm

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -712,6 +712,20 @@
     - W464#
     - W719#
 #
+- module: TesouroDireto.pm
+  state: working
+  added: 2022-02-06
+  changed: ~
+  removed: ~
+  urls:
+    - https://www.tesourodireto.com.br/titulos/precos-e-taxas.htm
+  apikey: false
+  notes: ~
+  testfile: tesouro_direto.t
+  testcases:
+    - Tesouro Prefixado 2026
+    - Tesouro IPCA+ 2045
+#
 - module: Troweprice.pm
   state: working
   added: TBD

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -92,6 +92,7 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     TSP
     TMX
     Tiaacref
+    TesouroDireto
     Troweprice
     USFedBonds
     Union
@@ -1599,6 +1600,7 @@ Finance::Quote::Tradeville,
 Finance::Quote::TSP,
 Finance::Quote::TMX,
 Finance::Quote::Tiaacref,
+Finance::Quote::TesouroDireto,
 Finance::Quote::Troweprice,
 Finance::Quote::USFedBonds,
 Finance::Quote::Union,

--- a/lib/Finance/Quote/TesouroDireto.pm
+++ b/lib/Finance/Quote/TesouroDireto.pm
@@ -1,0 +1,137 @@
+#!/usr/bin/perl -w
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#    02110-1301, USA
+#
+#
+# $Id: $
+
+package Finance::Quote::TesouroDireto;
+require 5.10.1;
+
+use strict;
+use warnings;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use LWP::UserAgent;
+use HTTP::Request::Common;
+use JSON;
+
+# VERSION
+
+sub methods { return (tesouro_direto => \&tesouro); }
+sub labels { return (tesouro_direto => [qw/exchange date isodate symbol name price last method currency/]); }
+
+sub tesouro
+{
+  my $quoter = shift;
+  my @funds = @_;
+  return unless @funds;
+
+  my $ua = $quoter->user_agent;
+
+  # Bad stuff to get around bad cert and ssl confs
+  $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0, SSL_cipher_list => 'DEFAULT:!DH');
+
+  my (%fundsymbol, %fundhash, @q, %info);
+
+  # create hash of all funds requested
+  foreach my $fund (@funds)
+  {
+      $fundhash{$fund} = 0;
+  }
+
+  my $url = "https://www.tesourodireto.com.br/json/br/com/b3/tesourodireto/service/api/treasurybondsinfo.json";
+  my $response = $ua->request(GET $url);
+
+  if ($response->is_success) {
+
+    my $data = decode_json($response->content)->{'response'};
+    my $quote_date = substr($data->{'TrsrBondMkt'}{'qtnDtTm'},0,10);
+    my @bounds_list = @{$data->{'TrsrBdTradgList'}};
+
+    foreach(@bounds_list) {
+
+      my $quote_name = $_->{'TrsrBd'}{'nm'};
+
+      if (exists $fundhash{$quote_name})
+      {
+        $fundhash{$quote_name} = 1;
+
+        $info{$quote_name, "exchange"} = "Tesouro Direto";
+        $info{$quote_name, "name"}     = $quote_name;
+        $info{$quote_name, "symbol"}   = $quote_name;
+        $info{$quote_name, "price"}    = $_->{'TrsrBd'}{'untrRedVal'};
+        $info{$quote_name, "last"}     = $_->{'TrsrBd'}{'untrRedVal'};
+	      $quoter->store_date(\%info, $quote_name, {isodate => $quote_date});
+        $info{$quote_name, "method"}   = "tesouro_direto";
+        $info{$quote_name, "currency"} = "BRL";
+        $info{$quote_name, "success"}  = 1;
+      }
+    }
+
+    # check to make sure a value was returned for every fund requested
+    foreach my $fund (keys %fundhash)
+    {
+      if ($fundhash{$fund} == 0)
+      {
+        $info{$fund, "success"}  = 0;
+        $info{$fund, "errormsg"} = "No data returned";
+      }
+    }
+  }
+  else
+  {
+    foreach my $fund (@funds)
+    {
+      $info{$fund, "success"}  = 0;
+      $info{$fund, "errormsg"} = "HTTP error";
+    }
+  }
+
+  ### result: %info
+
+  return wantarray() ? %info : \%info;
+}
+
+
+1;
+
+=head1 NAME
+
+Finance::Quote::TesouroDireto - Obtain quotes for Brazilian government bounds
+
+=head1 SYNOPSIS
+
+    use Finance::Quote;
+    $q = Finance::Quote->new;
+
+    %stockinfo = $q->fetch("tesouro_direto", "Tesouro IPCA+ 2045");
+
+=head1 DESCRIPTION
+
+This module obtains quotes for Brazilian government bounds, obtained from
+https://www.tesourodireto.com.br/titulos/precos-e-taxas.htm
+
+=head1 LABELS RETURNED
+
+The following labels may be returned by Finance::Quote::TesouroDireto:
+exchange, name, symbol, date, price, last, method, currency.
+
+=head1 SEE ALSO
+
+=cut

--- a/t/tesouro_direto.t
+++ b/t/tesouro_direto.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl -w
+use strict;
+use Test::More;
+use Finance::Quote;
+
+if ( not $ENV{"ONLINE_TEST"} ) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
+my @bounds = ("Tesouro Prefixado 2026", "Tesouro IPCA+ 2045");
+
+plan tests => 1 + 8*(1+$#bounds) + 1;
+
+my $q = Finance::Quote->new();
+my $year     = ( localtime() )[5] + 1900;
+my $lastyear = $year - 1;
+
+my %quotes = $q->fetch("tesouro_direto", @bounds);
+ok(%quotes);
+
+foreach my $bound (@bounds) {
+    ok( $quotes{$bound, "success"}, "$bound success" );
+    is( $quotes{$bound, "exchange"}, "Tesouro Direto", "$bound exchange correct" );
+    is( $quotes{$bound, "name"}, $bound, "$bound name correct" );
+    is( $quotes{$bound, "symbol"}, $bound, "$bound symbol correct" );
+    ok( $quotes{$bound, "price"} > 0, "$bound price positive" );
+    ok( $quotes{$bound, "last"} > 0, "$bound last positive" );
+    is( $quotes{$bound, "method"}, "tesouro_direto", "$bound method correct" );
+    is( $quotes{$bound, "currency"}, "BRL", "$bound currency correct" );
+}
+
+%quotes = $q->fetch( "tesouro_direto", "BOGUS" );
+ok( !$quotes{ "BOGUS", "success" }, "BOGUS failed" );


### PR DESCRIPTION
Tesouro Direto is Brazilian's National Treasury program for selling
public bounds to private investors. This module allows for the
retrieval of updated bounds value from the program's website.