### PR TITLE
Changes to ZA module

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -848,13 +848,14 @@
   testcases:
 #
 - module: ZA.pm
-  state: TBD
-  added: TBD
-  changed: ~
+  state: working
+  added: 
+  changed: 2022-05-10
   removed: ~
-  urls:
+  urls: https://www.sharenet.co.za/jse/$symbol
   apikey: false
-  notes: ~
+  notes: 
+    Module to acquire data from https://www.sharenet.co.za
   testfile: TBD
   testcases:
 #

--- a/lib/Finance/Quote/ZA.pm
+++ b/lib/Finance/Quote/ZA.pm
@@ -120,7 +120,7 @@ Finance::Quote->new().
 
 =head1 LABELS RETURNED
 
-The following labels will be returned: success currency name price date isodate symbol.
+The following labels will be returned: success currency name price date isodate symbol last source exchange.
 
 =head1 Terms & Conditions
 

--- a/lib/Finance/Quote/ZA.pm
+++ b/lib/Finance/Quote/ZA.pm
@@ -59,27 +59,37 @@ sub sharenet {
         my $result = $widget->scrape($reply);
 
         die "Failed to find $symbol" unless exists $result->{name};
-     
+
+        # Sharenet reports in minor denomination. Change this to major denomination
+        my $price = $result->{last};
+        $price =~ s/,//;
+        $price = $price / 100;
+
         ### RESULT : $result
-        
+
         $info{$symbol, 'success'}  = 1;
         $info{$symbol, 'currency'} = 'ZAR';
         $info{$symbol, 'name'}     = $result->{name};
-        $info{$symbol, 'price'}    = $result->{last};
-        $info{$symbol, 'price'}    =~ s/,//;
+        $info{$symbol, 'price'}    = $price;
+        $info{$symbol, 'last'}     = $price;
+
+        # Some applications would like to see the symbol in the returned data
+        $info{$symbol, 'symbol'}   = $symbol;
+        $info{$symbol, 'source'}   = 'sharenet.co.za';
+        $info{$symbol, 'exchange'} = 'JSE';
 
         if ($result->{day} =~ /(\d+)\s+(\w{3})/) {
           $quoter->store_date(\%info, $symbol, {day => $1, month => $2});
         }
       };
-      
+
       if ($@) {
         my $error = "Search failed: $@";
         $info{$symbol, 'success'}  = 0;
         $info{$symbol, 'errormsg'} = trim($error);
       }
     }
-    
+
     ### info : %info
 
     return wantarray() ? %info : \%info;
@@ -110,7 +120,7 @@ Finance::Quote->new().
 
 =head1 LABELS RETURNED
 
-The following labels will be returned: success currency name price date isodate.
+The following labels will be returned: success currency name price date isodate symbol.
 
 =head1 Terms & Conditions
 


### PR DESCRIPTION
Updated Sharenet parsing
    
    Sharenet reports share prices in minor denominations. All other examples
    reports in major denominations. GnuCash specifically is expecting major
    denomination.
    
    Added the following fields:
    * Exchange: JSE
    * Last: set to the same as price
    * Source: set to sharenet.co.za
    * Symbol: set to the input symbol

The only concern I have is the change in the interface in terms of major/minor denominations that may break other applications. According the wiki page only GnuCash is using this.