### PR TITLE
Use function=FX_DAILY in Finance::Quote::CurrencyRates::AlphaVantage (Fix #229)

### DIFF
--- a/lib/Finance/Quote/CurrencyRates/AlphaVantage.pm
+++ b/lib/Finance/Quote/CurrencyRates/AlphaVantage.pm
@@ -53,15 +53,15 @@ sub multipliers
 {
   my ($this, $ua, $from, $to) = @_;
 
-  my $url = 'https://www.alphavantage.co/query?function=CURRENCY_EXCHANGE_RATE';
+  my $url = 'https://www.alphavantage.co/query?function=FX_DAILY';
   my $try_cnt = 0;
   my $json_data;
   my $rate;
   do {
     $try_cnt += 1;
     my $reply = $ua->get($url
-        . '&from_currency=' . ${from}
-        . '&to_currency=' . ${to}
+        . '&from_symbol=' . ${from}
+        . '&to_symbol=' . ${to}
         . '&apikey=' . $this->{API_KEY});
 
     return unless ($reply->code == 200);
@@ -78,12 +78,13 @@ sub multipliers
     sleep (20) if (($try_cnt < 5) && ($json_data->{'Note'}));
   } while (($try_cnt < 5) && ($json_data->{'Note'}));
 
-  if( !$json_data->{'Realtime Currency Exchange Rate'} ) {
+  if( !$json_data->{'Time Series FX (Daily)'} ) {
     ### No data in JSON
 	  $rate = 0.0;
   } else {
+  my $target = substr($json_data->{'Meta Data'}->{'5. Last Refreshed'}, 0, 10);
   $rate =
-    $json_data->{'Realtime Currency Exchange Rate'}->{'5. Exchange Rate'};
+    $json_data->{'Time Series FX (Daily)'}->{$target}->{'4. close'};
   }
 
   ### Rate from JSON: $rate


### PR DESCRIPTION
AlphaVantage API [CURRENCY_EXCHANGE_RATE](https://www.alphavantage.co/documentation/#currency-exchange) seems to be available only to premium users.
This pull request is to change the code so that they can get the value even if they are not a premium user.

(Fix #229)