### PR TITLE
Revert "Use function=FX_DAILY in Finance::Quote::CurrencyRates::AlphaVantage (Fix #229)"

### DIFF
--- a/lib/Finance/Quote/CurrencyRates/AlphaVantage.pm
+++ b/lib/Finance/Quote/CurrencyRates/AlphaVantage.pm
@@ -53,15 +53,15 @@ sub multipliers
 {
   my ($this, $ua, $from, $to) = @_;
 
-  my $url = 'https://www.alphavantage.co/query?function=FX_DAILY';
+  my $url = 'https://www.alphavantage.co/query?function=CURRENCY_EXCHANGE_RATE';
   my $try_cnt = 0;
   my $json_data;
   my $rate;
   do {
     $try_cnt += 1;
     my $reply = $ua->get($url
-        . '&from_symbol=' . ${from}
-        . '&to_symbol=' . ${to}
+        . '&from_currency=' . ${from}
+        . '&to_currency=' . ${to}
         . '&apikey=' . $this->{API_KEY});
 
     return unless ($reply->code == 200);
@@ -78,13 +78,12 @@ sub multipliers
     sleep (20) if (($try_cnt < 5) && ($json_data->{'Note'}));
   } while (($try_cnt < 5) && ($json_data->{'Note'}));
 
-  if( !$json_data->{'Time Series FX (Daily)'} ) {
+  if( !$json_data->{'Realtime Currency Exchange Rate'} ) {
     ### No data in JSON
 	  $rate = 0.0;
   } else {
-  my $target = substr($json_data->{'Meta Data'}->{'5. Last Refreshed'}, 0, 10);
   $rate =
-    $json_data->{'Time Series FX (Daily)'}->{$target}->{'4. close'};
+    $json_data->{'Realtime Currency Exchange Rate'}->{'5. Exchange Rate'};
   }
 
   ### Rate from JSON: $rate


### PR DESCRIPTION
Reverts finance-quote/finance-quote#230
AlphaVantage changed the `CURRENCY_EXCHANGE_RATE` API back to not being a premium API.