### PR TITLE
Update for Fondsweb.pm

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -283,6 +283,22 @@
     - DE0008474511
     - LU0051755006
 #
+- module: Fondsweb.pm
+  state: working
+  added: TBD
+  changed: 2022-11-21
+  removed: ~
+  urls:
+  apikey: false
+  notes: ~
+  testfile: fondsweb.t
+  testcases:
+    - LU0804734787
+    - DE0008491002
+    - DE0008474503
+    - DE0008491051
+    - DE0009805507
+#
 - module: FTPortfolios.pm
   state: failing
   added: TBD

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -288,7 +288,7 @@
   added: TBD
   changed: 2022-11-21
   removed: ~
-  urls:
+  urls: https://www.fondsweb.com/de/
   apikey: false
   notes: ~
   testfile: fondsweb.t

--- a/lib/Finance/Quote/Fondsweb.pm
+++ b/lib/Finance/Quote/Fondsweb.pm
@@ -30,7 +30,7 @@ our $FONDSWEB_URL = "https://www.fondsweb.com/de/";
 sub methods { return ( fondsweb => \&fondsweb ); }
 
 {
-	my @labels = qw/name isin date isodate year_range nav last currency source method type/;
+	my @labels = qw/name symbol isin date isodate year_range nav last price currency source method type/;
 	sub labels { return (fondsweb => \@labels); }
 }
 
@@ -78,7 +78,8 @@ sub fondsweb {
 			# isin
 			my $isin_raw = $tree->findvalue( '//span[@class="text_bold"]');
 			my @isin = $isin_raw =~ m/^(\w\w\d+)\w./;
-			$info{ $symbol, 'isin' } = $isin[0];			
+			$info{ $symbol, 'isin' } = substr($isin[0], 0, 12);	
+			$info{ $symbol, 'symbol' } = substr($isin[0], 0, 12);	
 			
 			# date, isodate
 			my $raw_date = $tree->findvalue( '//i[@data-key="nav"]/..' );
@@ -158,7 +159,7 @@ The following labels are returned by Finance::Quote::Fondsweb:
 - name
 - nav
 - type
-- year_range
+
 
 =head1 REQUIREMENTS
 

--- a/lib/Finance/Quote/Fondsweb.pm
+++ b/lib/Finance/Quote/Fondsweb.pm
@@ -78,8 +78,13 @@ sub fondsweb {
 			# isin
 			my $isin_raw = $tree->findvalue( '//span[@class="text_bold"]');
 			my @isin = $isin_raw =~ m/^(\w\w\d+)\w./;
-			$info{ $symbol, 'isin' } = substr($isin[0], 0, 12);	
-			$info{ $symbol, 'symbol' } = substr($isin[0], 0, 12);	
+			my $sym=$isin[0];
+			my $symlen = length($sym);
+			if($symlen>12) {
+				$sym = substr($isin[0], 0, 12);
+			}
+			$info{ $symbol, 'isin' } = $sym;	
+			$info{ $symbol, 'symbol' } = $sym;	
 			
 			# date, isodate
 			my $raw_date = $tree->findvalue( '//i[@data-key="nav"]/..' );

--- a/t/fondsweb.t
+++ b/t/fondsweb.t
@@ -12,7 +12,7 @@ if (not $ENV{ONLINE_TEST}) {
 }
 
 my $q        = Finance::Quote->new();
-my @valid    = ('LU0804734787');
+my @valid    = ('LU0804734787','DE0008491002','DE0008474503','DE0008491051','DE0009805507');
 my @invalid  = qw/BOGUS/;
 my @symbols  = (@valid, @invalid);
 my $year     = (localtime())[5] + 1900;
@@ -27,7 +27,6 @@ my %check    = (
                 'nav'        => sub { $_[0] =~ /^[0-9.]+$/ },
                 'success'    => sub { $_[0] },
                 'type'       => sub { $_[0] eq 'fund' },
-                'year_range' => sub { $_[0] =~ /^[0-9.]+\s*-\s*[0-9.]+$/ },
                 );
 
 plan tests => 1 + %check*@valid + @invalid;


### PR DESCRIPTION
Fondsweb.pm failed in GnuCash because the ISIN was not retrieved correctly.
When both ISIN and WKN are present on the website, the module concatenated them. GnuCash expects the matched symbol returned, so I split the value after the 12th position.

Furthermore, I added some more test cases to fondsweb.t, and Modules-README.yml.