### PR TITLE
Quick fix for YahooJSON.pm and minor housekeeping prep for release 1.55

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{$NEXT}}
+	* Added TRV => CAD in AlphaVantage.pm. Issue #265 - PR #267
+	* Quick fix for YahooJSON.pm API
 	* URL Change for MorningstarJP. Issue #261
 	* Regex fix in FTfunds.pm and changed test cases ftfunds.t. PR #262
 

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -941,13 +941,16 @@
 - module: YahooJSON.pm
   state: working
   added:
-  changed: 2022-07-04
+  changed: 2023-05-07
   removed:
   urls:
-    - https://query1.finance.yahoo.com/v7/finance/quote?symbols=
+    - https://query1.finance.yahoo.com/v6/finance/quote?symbols=
   apikey: false
   notes: |
     Module to get data from Yahoo's API
+    See issue https://github.com/finance-quote/finance-quote/issues/264
+    Dependability of Yahoo REST API has been
+    spotty.
   testfile: yahoojson.t
   testcases:
     - SUZLON.BO
@@ -980,7 +983,7 @@
   urls: https://www.sharenet.co.za/jse/$symbol
   apikey: false
   notes: 
-    Module to acquire data from https://www.sharenet.co.za, PR #208
+    - Module to acquire data from https://www.sharenet.co.za, PR #208
   testfile: za.t
   testcases:
     - AGL

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -65,7 +65,9 @@ Finance::Quote is (soon to be) available via <a
 our <a href="download.html">download
 page</a>.</p>
       <h2 align="center">News</h2>
-      <p class="new"><b>2022-Dec-26</b>
+      <p class="new"><b>2023-May-13</b>
+        Release 1.55 is available from CPAN and Souceforge. See Changes file in distribution for details.
+      <p><b>2022-Dec-26</b>
         Release 1.54 is available from CPAN and Souceforge. A few modules updated and fixed. New modules - Sinvestor.pm and Tradegate.pm.
       <p><b>2022-Oct-08</b>
         Release 1.53 is available from CPAN and Souceforge. A few modules updated and fixed.

--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -35,7 +35,7 @@ use Time::Piece;
 
 # VERSION
 
-my $YIND_URL_HEAD = 'https://query1.finance.yahoo.com/v7/finance/quote?symbols=';
+my $YIND_URL_HEAD = 'https://query1.finance.yahoo.com/v6/finance/quote?symbols=';
 my $YIND_URL_TAIL = '';
 
 sub methods {


### PR DESCRIPTION
Changed https://query1.finance.yahoo.com/v7/finance/quote?symbols=PDM to https://query1.finance.yahoo.com/v6/finance/quote?symbols=PDM in lib/Finance/Quote/YahooJSON.pm

Modified Changes, Modules-README.yml, and htdocs/index.html in preparation for pushing release 1.55 to CPAN/PAUSE. Tentative release date, 05/13/2023.