### PR TITLE
MStarUK renamed to MorningstarUK

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+  * Renamed MStarUK.pm to MorningstarUK.pm
   * Added get_features method - PR #260
 
 1.55      2023-05-13 12:22:00-07:00 America/Los_Angeles

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -555,17 +555,6 @@
   testfile: TBD
   testcases:
 #
-- module: Morningstar.pm
-  state: TBD
-  added: TBD
-  changed: ~
-  removed: ~
-  urls:
-  apikey: false
-  notes: ~
-  testfile: TBD
-  testcases:
-#
 - module: MorningstarCH.pm
   state: working
   added: 2019-03-02
@@ -597,13 +586,13 @@
     - 2002013108
 #
 - module: MorningstarUK.pm
-  state: TBD
+  state: working
   added: TBD
   changed: 2023-05-20
   removed: ~
   urls:
   apikey: false
-  notes: Renamed from MStaruk.pm
+  notes: Renamed from MStaruk.pm 2023-05-20
   testfile: morningstarUK.t
   testcases:
 #

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -544,17 +544,6 @@
   testfile: TBD
   testcases:
 #
-- module: MStaruk.pm
-  state: TBD
-  added: TBD
-  changed: ~
-  removed: ~
-  urls:
-  apikey: false
-  notes: ~
-  testfile: TBD
-  testcases:
-#
 - module: ManInvestments.pm
   state: TBD
   added: TBD
@@ -606,6 +595,17 @@
   testcases:
     - 2009100101
     - 2002013108
+#
+- module: MorningstarUK.pm
+  state: TBD
+  added: TBD
+  changed: 2023-05-20
+  removed: ~
+  urls:
+  apikey: false
+  notes: Renamed from MStaruk.pm
+  testfile: morningstarUK.t
+  testcases:
 #
 - module: NSEIndia.pm
   state: working

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -80,10 +80,10 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     HU
     IEXCloud
     IndiaMutual
-    MStaruk
     MorningstarAU
     MorningstarCH
     MorningstarJP
+    MorningstarUK
     NSEIndia
     NZX
     OnVista
@@ -1687,10 +1687,10 @@ http://www.gnucash.org/
   Finance::Quote::HU,
   Finance::Quote::IEXCloud,
   Finance::Quote::IndiaMutual,
-  Finance::Quote::MStaruk,
   Finance::Quote::MorningstarAU,
   Finance::Quote::MorningstarCH,
   Finance::Quote::MorningstarJP,
+  Finance::Quote::MorningstarUK,
   Finance::Quote::NSEIndia,
   Finance::Quote::NZX,
   Finance::Quote::OnVista,

--- a/lib/Finance/Quote/MorningstarUK.pm
+++ b/lib/Finance/Quote/MorningstarUK.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-#  MStaruk.pm
+#  MorningstarUK.pm
 #
 #  Obtains quotes for UK Unit Trusts from http://morningstar.co.uk/ - please
 #  refer to the end of this file for further information.
@@ -26,7 +26,7 @@
 #
 
 
-package Finance::Quote::MStaruk;
+package Finance::Quote::MorningstarUK;
 require 5.005;
 
 use strict;
@@ -248,7 +248,7 @@ sub mstaruk_fund  {
 
 =head1 NAME
 
-Finance::Quote::mstaruk - Obtain UK Unit Trust quotes from morningstar.co.uk.
+Finance::Quote::MorningstarUK - Obtain UK Unit Trust quotes from morningstar.co.uk.
 
 =head1 SYNOPSIS
 
@@ -286,7 +286,7 @@ that your information only comes from the morningstar.co.uk website.
 
 =head1 LABELS RETURNED
 
-The following labels may be returned by Finance::Quote::mstaruk :
+The following labels may be returned by Finance::Quote::MorningstarUK :
 
     name, currency, last, date, time, price, nav, source, method,
     iso_date, net, p_change, success, errormsg.

--- a/lib/Finance/Quote/MorningstarUK.pm
+++ b/lib/Finance/Quote/MorningstarUK.pm
@@ -48,14 +48,16 @@ $MSTARUK_NEXT_URL	=	"http://www.morningstar.co.uk/uk/funds/snapshot/snapshot.asp
 
 # FIXME -
 
-sub methods { return (mstaruk => \&mstaruk_fund,
-		      			ukfunds => \&mstaruk_fund); }
+sub methods { return (morningstaruk => \&mstaruk_fund,
+                      mstaruk => \&mstaruk_fund,
+                      ukfunds => \&mstaruk_fund); }
 
 {
     my @labels = qw/name currency last date time price nav source iso_date method net p_change success errormsg/;
 
-    sub labels { return (mstaruk => \@labels,
-			 				ukfunds => \@labels); }
+    sub labels { return (morningstaruk => \@labels,
+                         mstaruk => \@labels,
+                         ukfunds => \@labels); }
 }
 
 #

--- a/t/morningstarUK.t
+++ b/t/morningstarUK.t
@@ -16,18 +16,19 @@ my $q      = Finance::Quote->new();
 my $year   = (localtime())[5] + 1900;
 my $lastyear = $year - 1;
 
-my %quotes = $q->morningstaruk("GB0031835118","GB0030880032","BOGUS");
+# my %quotes = $q->morningstaruk("GB0031835118","GB0030880032","BOGUS");
+my %quotes = $q->morningstaruk("GB00B61M9437","GB00B8H99P30","BOGUS");
 ok(%quotes);
 
 ### quotes : %quotes
 
 # Check the last values are defined.  These are the most
 #  used and most reliable indicators of success.
-ok($quotes{"GB0031835118","last"} > 0);
-ok($quotes{"GB0031835118","success"});
+ok($quotes{"GB00B61M9437","last"} > 0);
+ok($quotes{"GB00B61M9437","success"});
 
-ok($quotes{"GB0030880032","last"} > 0);
-ok($quotes{"GB0030880032","success"});
+ok($quotes{"GB00B8H99P30","last"} > 0);
+ok($quotes{"GB00B8H99P30","success"});
 
 # Check that bogus stocks return failure:
 

--- a/t/morningstarUK.t
+++ b/t/morningstarUK.t
@@ -16,7 +16,7 @@ my $q      = Finance::Quote->new();
 my $year   = (localtime())[5] + 1900;
 my $lastyear = $year - 1;
 
-my %quotes = $q->mstaruk("GB0031835118","GB0030880032","BOGUS");
+my %quotes = $q->morningstaruk("GB0031835118","GB0030880032","BOGUS");
 ok(%quotes);
 
 ### quotes : %quotes


### PR DESCRIPTION
Renamed MStarUK To be consistent with the other Morningstar modules. Kept mstaruk as a method but of course morningstaruk will use the mstaruk defined method.

Also changed symbols used for testing in morningstarUK.t, the ones formerly used were no longer traded.