### PR TITLE
New module - TwelveData.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 {{$NEXT}}
-    * Added get_features method - PR #260
-    * Added new TwelveData module
+	* Added new TwelveData module
+	* Updated YahooJSON.pm to use https://query2.finance.yahoo.com/v11 - PR #284
+	* Updated CurrencyRates/YahooJSON.pm to use https://query2.finance.yahoo.com/v11 - PR #284
+	* Bourso.pm - Squash anything but numbers and period in quote values.
+	* Renamed MStarUK.pm to MorningstarUK.pm
+	* Added get_features method - PR #260
 
 1.55      2023-05-13 12:22:00-07:00 America/Los_Angeles
 	* Added YahooJSON currency rate module PR #270

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 {{$NEXT}}
-  * Added get_features method - PR #260
+    * Added get_features method - PR #260
+    * Added new TwelveData module
 
 1.55      2023-05-13 12:22:00-07:00 America/Los_Angeles
 	* Added YahooJSON currency rate module PR #270

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -168,7 +168,7 @@
 - module: Bourso.pm
   state: working
   added:
-  changed: 2022-07-08
+  changed: 2023-05-22
   removed:
   urls: https://www.boursorama.com/cours/$stock
   apikey: false
@@ -179,11 +179,11 @@
     - 1rPAF
     - MSFT
     - FF11-SOLB
-    - 1rPCNP
     - 2rPDE000CX0QLH6
     - 1rPFR0010371401
     - 1rPCAC
     - 1rTBX4
+    - FR0010037341
 #
 - module: CSE.pm
   state: failing
@@ -262,9 +262,9 @@
 - module: CurrencyRates/YahooJSON.pm
   state: working
   Added: 2023-04-09
-  changed: ~
+  changed: 2023-05-26
   removed: ~
-  urls: https://query1.finance.yahoo.com/v6/finance/quote?symbols=
+  urls: https://query2.finance.yahoo.com/v11/finance/quoteSummary/...?modules=price
   apikey: false
   notes: |
     URL is constructed by adding "$from$to%3DX" to Yahoo URL.
@@ -544,29 +544,7 @@
   testfile: TBD
   testcases:
 #
-- module: MStaruk.pm
-  state: TBD
-  added: TBD
-  changed: ~
-  removed: ~
-  urls:
-  apikey: false
-  notes: ~
-  testfile: TBD
-  testcases:
-#
 - module: ManInvestments.pm
-  state: TBD
-  added: TBD
-  changed: ~
-  removed: ~
-  urls:
-  apikey: false
-  notes: ~
-  testfile: TBD
-  testcases:
-#
-- module: Morningstar.pm
   state: TBD
   added: TBD
   changed: ~
@@ -606,6 +584,17 @@
   testcases:
     - 2009100101
     - 2002013108
+#
+- module: MorningstarUK.pm
+  state: working
+  added: TBD
+  changed: 2023-05-20
+  removed: ~
+  urls:
+  apikey: false
+  notes: Renamed from MStaruk.pm 2023-05-20
+  testfile: morningstarUK.t
+  testcases:
 #
 - module: NSEIndia.pm
   state: working
@@ -995,10 +984,10 @@
 - module: YahooJSON.pm
   state: working
   added:
-  changed: 2023-05-07
+  changed: 2023-05-25
   removed:
   urls:
-    - https://query1.finance.yahoo.com/v6/finance/quote?symbols=
+    - https://query2.finance.yahoo.com/v11/finance/quoteSummary/...?modules=price,summaryDetail,defaultKeyStatistics
   apikey: false
   notes: |
     Module to get data from Yahoo's API

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -908,6 +908,25 @@
   testfile: TBD
   testcases:
 #
+- module: TwelveData.pm
+  state: working
+  added: 2023-05-26
+  changed:
+  removed:
+  urls:
+    - https://api.twelvedata.com/quote?symbol={$symbol}&apikey={$token}
+  apikey: true
+  notes: |
+    API Required.  Register at https://twelvedata.com.
+  testfile: twelvedata.t
+  testcases:
+    - MSFT
+    - AMZN
+    - AAPL
+    - GOOGL
+    - META
+    - BRK.A
+#
 - module: USFedBonds.pm
   state: failing
   added: ~

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -99,6 +99,7 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     TreasuryDirect
     Troweprice
     TSP
+    TwelveData
     Union
     XETRA
     YahooJSON
@@ -1704,6 +1705,7 @@ http://www.gnucash.org/
   Finance::Quote::TesouroDireto,
   Finance::Quote::TreasuryDirect,
   Finance::Quote::Troweprice,
+  Finance::Quote::TwelveData,
   Finance::Quote::Union,
   Finance::Quote::YahooJSON,
   Finance::Quote::ZA

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -80,10 +80,10 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     HU
     IEXCloud
     IndiaMutual
-    MStaruk
     MorningstarAU
     MorningstarCH
     MorningstarJP
+    MorningstarUK
     NSEIndia
     NZX
     OnVista
@@ -1688,10 +1688,10 @@ http://www.gnucash.org/
   Finance::Quote::HU,
   Finance::Quote::IEXCloud,
   Finance::Quote::IndiaMutual,
-  Finance::Quote::MStaruk,
   Finance::Quote::MorningstarAU,
   Finance::Quote::MorningstarCH,
   Finance::Quote::MorningstarJP,
+  Finance::Quote::MorningstarUK,
   Finance::Quote::NSEIndia,
   Finance::Quote::NZX,
   Finance::Quote::OnVista,

--- a/lib/Finance/Quote/TwelveData.pm
+++ b/lib/Finance/Quote/TwelveData.pm
@@ -53,17 +53,6 @@ sub parameters {
 sub twelvedata {
     my $quoter = shift;
 
-    my $token = exists $quoter->{module_specific_data}->{twelvedata}->{API_KEY} ? 
-                $quoter->{module_specific_data}->{twelvedata}->{API_KEY}        :
-                $ENV{"TWELVEDATA_API_KEY"};
-
-    if ( !defined $token ) {
-        $info{ $stock, 'success' } = 0;
-        $info{ $stock, 'errormsg' } =
-            'TwelveData API_KEY not defined. Get an API key at https://twelvedata.com';
-        next;
-    }
-    
     my @stocks = @_;
     my $quantity = @stocks;
     my ( %info, $reply, $url, $code, $desc, $body, $mark );
@@ -71,7 +60,19 @@ sub twelvedata {
     my $agent = $ua->agent();
     $ua->agent($AGENT);
 
+    my $token = exists $quoter->{module_specific_data}->{twelvedata}->{API_KEY} ? 
+                $quoter->{module_specific_data}->{twelvedata}->{API_KEY}        :
+                $ENV{"TWELVEDATA_API_KEY"};
+
     foreach my $symbol (@stocks) {
+
+        if ( !defined $token ) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } =
+                'TwelveData API_KEY not defined. Get an API key at https://twelvedata.com';
+            next;
+        }
+
         # Rate limit - first time through loop, mark is negative
         $mark -= time();
         ### TwelveData Mark: $mark

--- a/lib/Finance/Quote/TwelveData.pm
+++ b/lib/Finance/Quote/TwelveData.pm
@@ -57,7 +57,12 @@ sub twelvedata {
                 $quoter->{module_specific_data}->{twelvedata}->{API_KEY}        :
                 $ENV{"TWELVEDATA_API_KEY"};
 
-    die "TwelveData API_KEY not defined.  See documentation." unless defined $token;
+    if ( !defined $token ) {
+        $info{ $stock, 'success' } = 0;
+        $info{ $stock, 'errormsg' } =
+            'TwelveData API_KEY not defined. Get an API key at https://twelvedata.com';
+        next;
+    }
     
     my @stocks = @_;
     my $quantity = @stocks;
@@ -162,6 +167,18 @@ is a secret value written in hexidecimal.
 The API key may be set by either providing a module specific hash to
 Finance::Quote->new as in the above example, or by setting the environment
 variable TWELVEDATA_API_KEY.
+
+=head2 FREE KEY LIMITS
+
+The TwelveData free key limits usage to:
+
+=over
+
+=item 800 queries per day
+
+=item 8 queries per minute
+
+=back
 
 =head1 LABELS RETURNED
 

--- a/lib/Finance/Quote/TwelveData.pm
+++ b/lib/Finance/Quote/TwelveData.pm
@@ -1,0 +1,171 @@
+#!/usr/bin/perl -w
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#    02110-1301, USA
+
+package Finance::Quote::TwelveData;
+
+require 5.005;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use strict;
+use JSON qw( decode_json );
+use HTTP::Request::Common;
+use Text::Template;
+use DateTime::Format::Strptime qw( strptime strftime );
+
+# VERSION
+
+my $URL      = Text::Template->new(TYPE => 'STRING', SOURCE => 'https://api.twelvedata.com/quote?symbol={$symbol}&apikey={$token}');
+my $THROTTLE = 1.05 * 60.0/8.0;  # 5% more than maximum seconds / request for free tier
+my $AGENT    = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36';
+
+sub methods { 
+  return ( twelvedata => \&twelvedata );
+}
+
+sub parameters {
+  return ('API_KEY');
+}
+
+{
+    our @labels = qw/symbol name exchange currency isodate currency open high low close/;
+
+    sub labels {
+        return ( iexcloud => \@labels );
+    }
+}
+
+
+sub twelvedata {
+    my $quoter = shift;
+
+    my $token = exists $quoter->{module_specific_data}->{twelvedata}->{API_KEY} ? 
+                $quoter->{module_specific_data}->{twelvedata}->{API_KEY}        :
+                $ENV{"TWELVEDATA_API_KEY"};
+
+    die "TwelveData API_KEY not defined.  See documentation." unless defined $token;
+    
+    my @stocks = @_;
+    my $quantity = @stocks;
+    my ( %info, $reply, $url, $code, $desc, $body, $mark );
+    my $ua = $quoter->user_agent();
+    my $agent = $ua->agent();
+    $ua->agent($AGENT);
+
+    foreach my $symbol (@stocks) {
+        # Rate limit - first time through loop, mark is negative
+        $mark -= time();
+        ### TwelveData Mark: $mark
+        sleep($mark) if $mark > 0;
+        $mark  = time() + $THROTTLE;
+
+        $url   = $URL->fill_in(HASH => {symbol => $symbol, token => $token});
+        $reply = $ua->request(GET $url);
+        
+        ### url: $url
+        ### reply: $reply
+        
+        $code  = $reply->code;
+        $desc  = HTTP::Status::status_message($code);
+        $body  = $reply->content;
+  
+        if ($code != 200) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = $desc;
+            next;
+        }
+
+        my $quote;
+        eval {$quote = JSON::decode_json $body};
+        if ($@) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = $@;
+            next;
+        }
+
+        if (exists $quote->{'status'} and $quote->{'status'} eq 'error') {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = $quote->{'message'};
+            next;
+        }
+
+        if (not exists $quote->{'symbol'} or $quote->{'symbol'} ne $symbol) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = "TwevleData return and unexpected json result";
+            next;
+        }
+
+        $info{ $symbol, 'success' } = 1;
+        $info{ $symbol, 'symbol' }  = $symbol;
+        $info{ $symbol, 'name'}     = $quote->{'name'} if $quote->{'name'}; 
+        $info{ $symbol, 'exchange'} = $quote->{'exchange'} if $quote->{'exchange'}; 
+        $info{ $symbol, 'currency'} = $quote->{'currency'} if $quote->{'currency'}; 
+        $info{ $symbol, 'open' }    = $quote->{'open'} if $quote->{'open'}; 
+        $info{ $symbol, 'high' }    = $quote->{'high'} if $quote->{'high'};
+        $info{ $symbol, 'low' }     = $quote->{'low'} if $quote->{'low'};
+        $info{ $symbol, 'close' }   = $quote->{'close'} if $quote->{'close'};
+        $info{ $symbol, 'volume' }  = $quote->{'volume'} if $quote->{'volume'};
+        $info{ $symbol, 'method' }  = 'twelvedata';
+       
+        my $time     = strptime('%s', int($quote->{'timestamp'}));
+        my $isodate  = strftime('%F', $time);
+        $quoter->store_date( \%info, $symbol, { isodate => $isodate } );
+    }
+
+    $ua->agent($agent);
+
+    return wantarray() ? %info : \%info;
+}
+1;
+
+=head1 NAME
+
+Finance::Quote::TwelveData - Obtain quotes from https://twelvedata.com
+
+=head1 SYNOPSIS
+
+    use Finance::Quote;
+    
+    $q = Finance::Quote->new('TwelveData', twelvedata => {API_KEY => 'your-twelvedata-api-key'});
+
+    %info = Finance::Quote->fetch("IBM", "AAPL");
+
+=head1 DESCRIPTION
+
+This module fetches information from https://twelvedata.com.
+
+This module is loaded by default on a Finance::Quote object. It's
+also possible to load it explicitly by placing "TwelveData" in the argument
+list to Finance::Quote->new().
+
+This module provides the "twelvedata" fetch method.
+
+=head1 API_KEY
+
+https://twelvedata.com requires users to register and obtain an API key, which
+is a secret value written in hexidecimal.
+
+The API key may be set by either providing a module specific hash to
+Finance::Quote->new as in the above example, or by setting the environment
+variable TWELVEDATA_API_KEY.
+
+=head1 LABELS RETURNED
+
+The following labels may be returned by Finance::Quote::TwelveData :
+    symbol name exchange currency isodate currency open high low close
+
+=cut

--- a/t/twelvedata.t
+++ b/t/twelvedata.t
@@ -1,0 +1,63 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use Test::More;
+use Finance::Quote;
+use Date::Simple qw(today);
+use Scalar::Util qw(looks_like_number);
+use Date::Range;
+use Date::Manip;
+
+if (not $ENV{ONLINE_TEST}) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
+if ( not $ENV{"TEST_TWELVEDATA_API_KEY"} ) {
+    plan skip_all => 'Set $ENV{"TEST_TWELVEDATA_API_KEY"} to run this test';
+}
+
+my @valid    = qw/MSFT AMZN AAPL GOOGL META BRK.A/;
+my @invalid  = ('BOGUS');
+my @symbols  = (@valid, @invalid);
+
+my $q        = Finance::Quote->new('TwelveData', timeout => 120, twelvedata => {API_KEY => $ENV{"TEST_TWELVEDATA_API_KEY"}});
+my $today    = today();
+my $window   = 7;
+
+my %check    = (# Tests are called with (value_to_test, symbol, quote_hash_reference)
+                'success'  => sub {$_[0] == 1},
+                'symbol'   => sub {$_[0] eq $_[1]},
+                'name'     => sub {defined $_[0]},
+                'exchange' => sub {defined $_[0]},
+                'currency' => sub {defined $_[0]},
+                'open'     => sub {defined $_[0] and looks_like_number($_[0])},
+                'high'     => sub {defined $_[0] and looks_like_number($_[0])},
+                'low'      => sub {defined $_[0] and looks_like_number($_[0])},
+                'close'    => sub {defined $_[0] and looks_like_number($_[0])},
+                'volume'   => sub {defined $_[0] and looks_like_number($_[0])},
+                'method'   => sub {$_[0] eq 'twelvedata'},
+                'isodate'  => sub {Date::Range->new($today - $window, $today)->includes(Date::Simple::ISO->new($_[0]))},
+               );
+
+plan tests => 1 + %check*@valid + @invalid;
+
+my %quotes = $q->twelvedata(@symbols);
+ok(%quotes);
+
+### [<now>] quotes: %quotes
+
+foreach my $symbol (@valid) {
+  while (my ($key, $lambda) = each %check) {
+    ok($lambda->($quotes{$symbol, $key}, $symbol, \%quotes), "$key -> " . (defined $quotes{$symbol, $key} ? $quotes{$symbol, $key} : '<undefined>'));
+  }
+}
+    
+foreach my $symbol (@invalid) {
+  ok((not $quotes{'BOGUS', 'success'}), 'failed as expected');
+}
+


### PR DESCRIPTION
Added TwelveData.pm for quotes.  Updated Changes and Modules-README.yml.

In development tree, test with
```bash
$ ONLINE_TEST=1 TEST_TWELVEDATA_API_KEY=xxx...xx dzil run prove -lv t/twelvedata.t
```

Register at https://twelvedata.com to get API key.

- Free tier limits rate to 8 quotes per minute.  This is built into the module - but if someone subscribes we don't have a way to remove rate limit.
- TwelveData can also do currency conversion, but companion Currency module not written