### PR TITLE
move use strict to be the first statement

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 {{$NEXT}}
 
-    * move use strict to be the first statement in TreasuryDirect.pm and TwelveData.pm
-    * remove old perl version requirement statements from TreasuryDirect.pm and TwelveData.pm
-    * removed Data::Dumper that caused another test to fail from TreasuryDirect.pm
+    * move use strict to be the first statement in TreasuryDirect.pm and TwelveData.pm #290
+    * remove old perl version requirement statements from TreasuryDirect.pm and TwelveData.pm #290
+    * removed Data::Dumper that caused another test to fail from TreasuryDirect.pm #290
 
 1.56      2023-05-29 14:56:23-07:00 America/Los_Angeles
   * Replaced Tradeville.pm with BVB.pm - Issue #269

--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 {{$NEXT}}
 
-    * move use strict to be the first statement
-    * remove old perl version requirement statements.
-    * removed Data::Dumper that caused another test to fail
+    * move use strict to be the first statement in TreasuryDirect.pm and TwelveData.pm
+    * remove old perl version requirement statements from TreasuryDirect.pm and TwelveData.pm
+    * removed Data::Dumper that caused another test to fail from TreasuryDirect.pm
 
 1.56      2023-05-29 14:56:23-07:00 America/Los_Angeles
   * Replaced Tradeville.pm with BVB.pm - Issue #269

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+    * move use strict to be the first statement
+    * remove old perl version requirement statements.
+    * removed Data::Dumper that caused another test to fail
+
 1.56      2023-05-29 14:56:23-07:00 America/Los_Angeles
   * Replaced Tradeville.pm with BVB.pm - Issue #269
 	* Added new TwelveData module

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -874,7 +874,7 @@
 - module: TreasuryDirect.pm
   state: working
   added: 2022-07-20
-  changed:
+  changed: 2023-05-31
   removed:
   urls:
     - https://www.treasurydirect.gov/GA-FI/FedInvest/todaySecurityPriceDate.htm
@@ -915,7 +915,7 @@
 - module: TwelveData.pm
   state: working
   added: 2023-05-26
-  changed:
+  changed: 2023-05-31
   removed:
   urls:
     - https://api.twelvedata.com/quote?symbol={$symbol}&apikey={$token}

--- a/lib/Finance/Quote/TreasuryDirect.pm
+++ b/lib/Finance/Quote/TreasuryDirect.pm
@@ -10,7 +10,9 @@ perl -MData::Dumper -MFinance::Quote -le '$q = Finance::Quote->new(); print Dump
 =cut
 
 package Finance::Quote::TreasuryDirect;
-require 5.004;
+use strict;
+use warnings;
+
 
 #
 # Modification of Rolf Endres' Finance::Quote::ZA
@@ -21,16 +23,12 @@ require 5.004;
 
 # VERSION
 
-use strict;
-use warnings;
-
 use vars qw /$VERSION/ ;
 
 use LWP::UserAgent;
 use HTTP::Request::Common;
 use HTML::TableExtract;
 use HTTP::Request;
-use Data::Dumper;
 
 my $TREASURY_DIRECT_URL = 'https://www.treasurydirect.gov/GA-FI/FedInvest/todaySecurityPriceDate.htm';
 

--- a/lib/Finance/Quote/TwelveData.pm
+++ b/lib/Finance/Quote/TwelveData.pm
@@ -15,13 +15,12 @@
 #    02110-1301, USA
 
 package Finance::Quote::TwelveData;
+use strict;
 
-require 5.005;
 
 use constant DEBUG => $ENV{DEBUG};
 use if DEBUG, 'Smart::Comments';
 
-use strict;
 use JSON qw( decode_json );
 use HTTP::Request::Common;
 use Text::Template;


### PR DESCRIPTION
remove old perl version requirement statements. They are so old, not really relevant today.

Also removed Data::Dumper that caused another test to fail after the move of use strict;

closes #290