### PR TITLE
Fix wrong key in labels() method in twelvedata

### DIFF
--- a/lib/Finance/Quote/TwelveData.pm
+++ b/lib/Finance/Quote/TwelveData.pm
@@ -45,7 +45,7 @@ sub parameters {
     our @labels = qw/symbol name exchange currency isodate currency open high low close/;
 
     sub labels {
-        return ( iexcloud => \@labels );
+        return ( twelvedata => \@labels );
     }
 }
 


### PR DESCRIPTION
This fixes a copy and paste bug from the first draft of the module.  Not clear what (if any) impact this mistake would have on typical usage of the module.