### PR TITLE
IndiaMutual.pm: TMP and TMPDIR env variables do not include trailing slashes in all distributions

### DIFF
--- a/lib/Finance/Quote/IndiaMutual.pm
+++ b/lib/Finance/Quote/IndiaMutual.pm
@@ -24,8 +24,8 @@ $AMFI_MAIN_URL = ("http://www.amfiindia.com/");
 $AMFI_URL = ("https://www.amfiindia.com/spages/NAVAll.txt");
 
 # amfinavlist.txt is a cache-file. keep it until updated on the website since this is a 1meg file.
-my $cachedir = $ENV{TMPDIR} // $ENV{TEMP} // '/tmp/';
-$AMFI_NAV_LIST = $cachedir."amfinavlist.txt";
+my $cachedir = $ENV{TMPDIR} // $ENV{TEMP} // '/tmp';
+$AMFI_NAV_LIST = $cachedir."/amfinavlist.txt";
 
 sub methods { return (indiamutual => \&amfiindia,
                       amfiindia => \&amfiindia); }


### PR DESCRIPTION
The location of the cache-file is constructed using TMPDIR and TEMP environment variables and these are not not guaranteed to include a trailing slash in all setups. The location of the amfinavlist.txt cache was changed such that a slash is prefixed to the file name