### PR TITLE
Changed IndiaMutual.pm to use IO::String

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Replaced cached file with IO::String object in IndiaMutual.pm
 	* Fixed missing date in AEX.pm - Issue #298
 	* Fixed Examples in POD Documentation in a few modules - PR #295
 	* move use strict to be the first statement in TreasuryDirect.pm and TwelveData.pm #290

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -535,7 +535,7 @@
 - module: IndiaMutual.pm
   state: working
   added: TBD
-  changed: ~
+  changed: 2023-06-06
   removed: ~
   urls: https://www.amfiindia.com/spages/NAVAll.txt
   apikey: false
@@ -544,7 +544,7 @@
   testcases:
     - 102676
     - 103131
-    - 101599
+    - 148181
     - INF194K01W88
     - INF090I01FN7
     - INF082J01127

--- a/lib/Finance/Quote/IndiaMutual.pm
+++ b/lib/Finance/Quote/IndiaMutual.pm
@@ -43,7 +43,7 @@ sub methods { return (indiamutual => \&amfiindia,
                       amfiindia => \&amfiindia); }
 
 {
-    my @labels = qw/method source link name currency date isodate nav rprice sprice/;
+    my @labels = qw/method source link name currency date isodate nav/;
     sub labels { return (indiamutual => \@labels,
                          amfiindia => \@labels); }
 }
@@ -144,10 +144,11 @@ Finance::Quote::IndiaMutual  - Obtain Indian mutual fund prices from amfiindia.c
 
     $q = Finance::Quote->new;
 
-    %stockinfo = $q->fetch("indiamutual", "amfiindia-code"); # Can
-failover to other methods
-    %stockinfo = $q->fetch("amfiindia", "amfiindia-code"); # Use this
-module only.
+    # Can failover to other methods
+    %stockinfo = $q->fetch("indiamutual", "amfiindia-code");
+
+    # Use this module only
+    %stockinfo = $q->fetch("amfiindia", "amfiindia-code");
 
     # NOTE: currently no failover methods exist for indiamutual
 
@@ -169,14 +170,29 @@ http://www.amfiindia.com/nav-history-download
 
 Information available from amfiindia may include the following labels:
 
-method link source name currency nav rprice sprice.  The link
-label will be a url location for the NAV list table for all funds.
+=over
+
+=item method
+
+=item link
+
+=item source
+
+=item name
+
+=item currency
+
+=item nav
+
+=back
+
+The link label will be a url location for the NAV list table for all funds.
 
 =head1 NOTES
 
 AMFI provides a link to download a text file containing all the
-NAVs. This file is mirrored in a local file /tmp/amfinavlist.txt. The local
-mirror serves only as a cache and can be safely removed.
+L<NAVs|https://www.amfiindia.com/spages/NAVAll.txt>. It is processed
+in memory using the L<IO::String> Perl module.
 
 =head1 SEE ALSO
 

--- a/t/indiamutual.t
+++ b/t/indiamutual.t
@@ -10,8 +10,8 @@ if (not $ENV{ONLINE_TEST}) {
 # Test IndiaMutual functions.
 
 my $q      = Finance::Quote->new();
-my @funds = ("102676", "103131", "101599", 
-	     "INF194K01W88", "INF090I01FN7", "INF082J01127");
+my @funds = ("102676", "103131", "148181", "INF194K01W88", "INF090I01FN7",
+             "INF082J01127");
 my $year = (localtime())[5] + 1900;
 my $lastyear = $year - 1;
 


### PR DESCRIPTION
Changed IndiaMutual.pm to use IO::String object instead of downloading and parsing a file. Eliminates issues caused by incorrect or non-existing directories. Changed a non-working test case. Updated Changes and Modules-README.yml files.