### PR TITLE
New module Consorsbank.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Added Consorsbank module
 	* YahooWeb.pm - Fixed incorrect pricing for single character symbols
 	  and changed URL to get trade date - Issues #314 #319
 	* Another fix to the URL in YahooJSON and CurrencyRates/YahooJSON - Issue #318

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -249,6 +249,32 @@
   testfile: TBD
   testcases:
 #
+- module: Consorsbank.pm
+  state: working
+  added: 2023-07-20
+  changed: ~
+  removed: ~
+  urls:
+    - https://www.consorsbank.de/web-financialinfo-service/api/marketdata/stocks?id=$symbol&field=QuotesV1&field=BasicV1
+  apikey: false
+  notes: |
+    Module to acquire data from https://www.consorsbank.de.
+  testfile: consorsbank.t
+  testcases:
+    - DE0007664005
+    - 766400
+    - DE0008469008
+    - FR0003500008
+    - _81341467
+    - DE000CX0QLH6
+    - DE0001102580
+    - FR0010411884
+    - LU1508476725
+    - EU0009652759
+    - FR0010037341
+    - DE000DB4CAT1
+    - BOGUS
+#
 - module: Currencies.pm
   state: working
   added: TBD

--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ http://www.gnucash.org/
     Finance::Quote::CSE,
     Finance::Quote::Cdnfundlibrary,
     Finance::Quote::Comdirect,
+    Finance::Quote::Consorsbank,
     Finance::Quote::Currencies,
     Finance::Quote::DWS,
     Finance::Quote::Deka,

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -68,6 +68,7 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     CSE
     Cdnfundlibrary
     Comdirect
+    Consorsbank
     Currencies
     DWS
     Deka
@@ -1688,6 +1689,7 @@ http://www.gnucash.org/
   Finance::Quote::CSE,
   Finance::Quote::Cdnfundlibrary,
   Finance::Quote::Comdirect,
+  Finance::Quote::Consorsbank,
   Finance::Quote::Currencies,
   Finance::Quote::DWS,
   Finance::Quote::Deka,

--- a/lib/Finance/Quote/Consorsbank.pm
+++ b/lib/Finance/Quote/Consorsbank.pm
@@ -1,0 +1,256 @@
+#!/usr/bin/perl -w
+
+# Copyright (C) 2023, Stephan Gambke <s7eph4n@gmail.com>
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA
+
+require 5.005;
+
+use strict;
+use warnings;
+
+package Finance::Quote::Consorsbank;
+
+use LWP::UserAgent;
+use JSON qw( decode_json );
+use DateTime;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+use if DEBUG, 'Data::Dumper';
+
+# VERSION
+
+my $CONSORS_URL = 'https://www.consorsbank.de/web-financialinfo-service/api/marketdata/stocks?';
+my $CONSORS_SOURCE_BASE_URL = 'https://www.consorsbank.de/web/Wertpapier/';
+
+sub methods {
+    return (
+        consorsbank => \&consorsbank,
+        europe => \&consorsbank
+    );
+}
+
+{
+    # Correspondence of FQ labels to Consorsbank API fields
+
+    # success                            Did the stock successfully return information? (true/false)
+    # errormsg    Info.Errors.ERROR_MESSAGE  If success is false, this field may contain the reason why.
+    # symbol      Info.ID                Lookup symbol (ISIN, WKN, ticker symbol)
+    # name        BasicV1.NAME_SECURITY  Company or Mutual Fund Name
+    # method      'consorsbank'          The module (as could be passed to fetch) which found this information.
+    # source                             Source URL, either general website or direct human-readable deep link
+    # exchange    CONSORS_EXCHANGE_NAME  The exchange the information was obtained from.
+    # currency    ISO_CURRENCY           ISO currency code
+
+    # ask         ASK                    Ask
+    # avg_vol                            Average Daily Vol
+    # bid         BID                    Bid
+    # cap                                Market Capitalization
+    # close       PREVIOUS_LAST          Previous Close
+    # date        DATETIME_PRICE         Last Trade Date  (MM/DD/YY format)
+    # day_range   HIGH, LOW              Day's Range
+    # div                                Dividend per Share
+    # div_date                           Dividend Pay Date
+    # div_yield                          Dividend Yield
+    # eps                                Earnings per Share
+    # ex_div                             Ex-Dividend Date.
+    # high        HIGH                   Highest trade today
+    # last        PRICE                  Last Price
+    # low         LOW                    Lowest trade today
+    # nav                                Net Asset Value
+    # net         PERFORMANCE            Net Change
+    # open        FIRST                  Today's Open
+    # p_change    PERFORMANCE_PCT        Percent Change from previous day's close
+    # pe                                 P/E Ratio
+    # time        DATETIME_PRICE         Last Trade Time
+    # type                               The type of equity returned
+    # volume      TOTAL_VOLUME           Volume
+    # year_range  HIGH_PRICE_1_YEAR - LOW_PRICE_1_YEAR   52-Week Range
+    # yield                              Yield (usually 30 day avg)
+
+    my @labels = qw/
+        symbol
+        name
+        method
+        source
+        exchange
+        currency
+        ask
+        bid
+        close
+        date
+        day_range
+        high
+        last
+        low
+        net
+        open
+        p_change
+        volume
+        year_range
+    /;
+
+    # Function that lists the data items available from Consorsbank
+    sub labels {
+        return (
+            consorsbank => \@labels,
+            europe => \@labels);
+    }
+}
+
+sub consorsbank {
+
+    # a Finance::Quote object
+    my Finance::Quote $quoter = shift;
+
+    # a list of zero or more symbol names
+    my @symbols = @_ or return;
+
+    # user_agent() provides a ready-to-use LWP::UserAgent
+    my $ua = $quoter->user_agent;
+
+    my %info;
+
+    for my $symbol (@symbols) {
+
+        ### $symbol
+
+        $info{ $symbol, 'symbol' } = $symbol;
+        $info{ $symbol, 'success'  } = 1;
+        $info{ $symbol, 'errormsg' } = '';
+
+        my $query = $CONSORS_URL . "id=$symbol&field=QuotesV1&field=BasicV1";
+        my $response = $ua->get($query);
+
+        unless	($response->is_success) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = "Unable to fetch data from the Consorsbank server for $symbol.  Error: " . $response->status_line;
+            next;
+        }
+
+        unless ($response->header('content-type') =~ m|application/json|i) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = "Invalid content-type from Consorsbank server for $symbol.  Expected: application/json, received: " . $response->header('content-type');
+            next;
+        }
+
+        my $json = $response->content;
+
+
+        ### [<here>] $json:
+        ### $json
+
+        my $data;
+        eval { $data = JSON::decode_json($json) };
+
+        if ($@) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = "Failed to parse JSON data for $symbol.  Error: $@.";
+            ### $@
+            next;
+        }
+
+        ### [<here>] $data:
+        ### $data
+
+        if ( defined $data->[0]{'Info'}{'Errors'} ){
+            ### API Error: $data->[0]{'Info'}{'Errors'}
+            $info{ $symbol, 'success' } = 0;
+
+            if ( $data->[0]{'Info'}{'Errors'}[0]{'ERROR_CODE'} eq 'IDMS' ){
+                $info{ $symbol, 'errormsg' } = "Invalid symbol: $symbol";
+            } else {
+                $info{ $symbol, 'errormsg' } = $data->[0]{'Info'}{'Errors'}[0]{'ERROR_MESSAGE'}
+            }
+            next;
+        }
+
+        my $quote = $data->[0]{'QuotesV1'}[0];
+
+        ### [<here>] $symbol:
+        ### $symbol
+        $info{ $symbol, 'symbol'     } = $data->[0]{'Info'}{'ID'}               if (defined $data->[0]{'Info'}{'ID'}) ;
+        $info{ $symbol, 'name'       } = $data->[0]{'BasicV1'}{'NAME_SECURITY'} if (defined $data->[0]{'BasicV1'}{'NAME_SECURITY'});
+        $info{ $symbol, 'method'     } = 'consorsbank';
+        $info{ $symbol, 'source'     } = $CONSORS_SOURCE_BASE_URL . $data->[0]{'Info'}{'ID'};
+
+        $info{ $symbol, 'day_range'  } = $quote->{'HIGH'} - $quote->{'LOW'}     if (defined $quote->{'HIGH'} && defined $quote->{'LOW'});
+
+        $info{ $symbol, 'year_range' } = $quote->{'HIGH_PRICE_1_YEAR'} - $quote->{'LOW_PRICE_1_YEAR'}
+                                                                                if (defined $quote->{'HIGH_PRICE_1_YEAR'} && defined $quote->{'LOW_PRICE_1_YEAR'});
+
+        my %mapping = ('exchange' => 'CONSORS_EXCHANGE_NAME', 'currency' => 'ISO_CURRENCY', 'ask' => 'ASK',
+            'bid' => 'BID', 'close' => 'PREVIOUS_LAST', 'high' => 'HIGH', 'last' => 'PRICE',
+            'low' => 'LOW', 'net' => 'PERFORMANCE', 'open' => 'FIRST', 'p_change' => 'PERFORMANCE_PCT',
+            'volume' => 'TOTAL_VOLUME' );
+
+        while ((my $fqkey, my $cbkey) = each (%mapping)) {
+            $info{ $symbol, $fqkey } = $quote->{$cbkey} if (defined $quote->{$cbkey});
+        }
+
+        $quote->{'DATETIME_PRICE'} = DateTime->now->iso8601 unless defined $quote->{'DATETIME_PRICE'};
+        ($info{ $symbol, 'date' }, $info{ $symbol, 'time' }) = split /T/, $quote->{'DATETIME_PRICE'};
+        $quoter->store_date(\%info, $symbol, { isodate => $info{ $symbol, 'date' } });
+
+        unless (defined $info{ $symbol, 'last'} ) {
+            $info{ $symbol, 'success' } = 0;
+            $info{ $symbol, 'errormsg' } = "The server did not return a price for $symbol.";
+            next
+        }
+
+    }
+
+    ### [<here>] %info:
+    ### %info
+
+    return wantarray() ? %info : \%info;
+}
+1;
+__END__
+
+=head1 NAME
+
+Finance::Quote::Consorsbank - Obtain quotes from Consorsbank.
+
+=head1 SYNOPSIS
+
+	use Finance::Quote;
+	$q = Finance::Quote->new;
+	%stockinfo = $q->fetch("consorsbank","DE0007664005"); # Only query consorsbank using ISIN.
+	%stockinfo = $q->fetch("consorsbank","766400");       # Only query consorsbank using WKN.
+	%stockinfo = $q->fetch("europe","DE0007664005");      # Failover to other sources OK.
+
+=head1 DESCRIPTION
+
+This module obtains information from Consorsbank (https://www.consorsbank.de).
+
+It accepts ISIN or German WKN as requested symbol.
+
+This module is loaded by default on a Finance::Quote object.  It's
+also possible to load it explicitly by placing "Consorsbank" in the argument
+list to Finance::Quote->new().
+
+This module provides both the "consorsbank" and "europe" fetch methods.
+Please use the "europe" fetch method if you wish to have failover with other
+sources for European stock exchanges. Using the "consorsbank" method will
+guarantee that your information only comes from the Consorsbank service.
+
+=head1 LABELS RETURNED
+
+The following labels may be returned by Finance::Quote::Consorsbank:
+
+ask, bid, close, date, day_range, high, last, low, net, open, p_change, volume, year_range
+
+=cut

--- a/t/consorsbank.t
+++ b/t/consorsbank.t
@@ -1,0 +1,100 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use Test::More;
+use Finance::Quote;
+use Scalar::Util qw(looks_like_number);
+use Date::Simple qw(today);
+use Date::Range;
+use Date::Manip;
+
+if ( not $ENV{ONLINE_TEST} ) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
+my $CONSORS_SOURCE_BASE_URL = 'https://www.consorsbank.de/web/Wertpapier/';
+
+# Test cases for Consorsbank
+
+my %valid    = (
+    'DE0007664005' => {currency => 'EUR', days => 3, name => 'VOLKSWAGEN AG'},              # Stock (ISIN), EUR
+    '766400'       => {currency => 'EUR', days => 3, name => 'VOLKSWAGEN AG'},              # Stock (WKN), EUR
+
+    'DE0008469008' => {currency => 'EUR', days => 7, name => 'DAX PERFORMANCE INDEX'},      # Index: DAX
+    'FR0003500008' => {currency => 'EUR', days => 7, name => 'CAC 40 INDEX'},               # Index: CAC 40
+    '_81341467'    => {currency => 'USD', days => 7, name => 'S&P 500 (BNPP INDICATION)'},  # Index (Consors internal ID)
+
+    'DE000CX0QLH6' => {currency => 'EUR', days => 7, name => 'OE TURBO BULL AUF GOLD'},                   # Warrant
+    'DE0001102580' => {currency => 'EUR', days => 7, name => 'BUNDESREP.DEUTSCHLAND ANL.V.2022 (2032)'},  # Bond
+    'FR0010411884' => {currency => 'EUR', days => 7, name => 'Lyxor CAC 40 Daily (-2x) Inverse ETF Acc'}, # ETF, EUR
+    'LU1508476725' => {currency => 'EUR', days => 7, name => 'Allianz Global Equity Insights A EUR'},     # Fund, EUR
+    'EU0009652759' => {currency => 'USD', days => 7, name => 'EURO / US-DOLLAR (EUR/USD)'}, # Currency
+);
+
+my %invalid  = (
+    'FR0010037341' => undef, # known by Consors, but no prices tracked on default exchange
+    'DE000DB4CAT1'   => undef, # Commodities: Brent
+    'BOGUS' => undef,
+);
+
+my @symbols  = (keys %valid, keys %invalid);
+my $today    = today();
+
+my %check    = (# Tests are called with (value_to_test, symbol, quote_hash_reference)
+    'success'  => sub {$_[0]},
+    'symbol'   => sub {$_[0] eq $_[1]},
+    'name'     => sub {$_[0] eq $valid{$_[1]}{name}},
+    'method'   => sub {$_[0] eq 'consorsbank'},
+    'source'   => sub {$_[0] eq $CONSORS_SOURCE_BASE_URL . $_[1]},
+    'exchange' => sub {$_[0] =~ /^.+$/},
+    'currency' => sub {defined $valid{$_[1]}{currency} ? $_[0] eq $valid{$_[1]}{currency} : 1},
+    'last'     => sub {looks_like_number($_[0])},                      # last is REQUIRED
+
+    'ask'      => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # ask is optional
+    'bid'      => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # bid is optional
+    'close'    => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # close is optional
+    'day_range' => sub {defined $_[0] ? looks_like_number($_[0]) : 1}, # day_range is optional
+    'high'     => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # high is optional
+    'low'      => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # low is optional
+    'net'      => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # net is optional
+    'open'     => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # open is optional
+    'p_change' => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # p_change is optional
+    'time'     => sub {defined $_[0] ? $_[0] =~ /^\d{2}:\d{2}:\d{2}([+-]\d{4})?$/ : 1},  # p_change is optional
+    'volume'   => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # volume is optional
+    'year_range' => sub {defined $_[0] ? looks_like_number($_[0]) : 1},  # year_range is optional
+
+    'date'     => sub {
+        my $a = Date::Manip::Date->new(); $a->parse_format('%m/%d/%Y', $_[0]);
+        my $b = Date::Manip::Date->new(); $b->parse_format('%Y-%m-%d', $_[2]->{$_[1], 'isodate'});
+        return $_[0] =~ /^\d{2}\/\d{2}\/\d{4}$/ && $a->cmp($b) == 0;},
+    'isodate'  => sub {Date::Range->new($today - $valid{$_[1]}{days}, $today)->includes(Date::Simple::ISO->new($_[0]))},
+);
+my $q = Finance::Quote->new();
+
+plan tests => 1 + %check * %valid + %invalid;
+
+my %quotes = $q->fetch('consorsbank', @symbols);
+
+ok(%quotes);
+
+### [<now>] quotes: %quotes
+
+foreach my $symbol (keys %valid) {
+    while (my ($key, $lambda) = each %check) {
+        ### check key: $key
+        ### check res: $quotes{$symbol, $key}
+        ok($lambda->($quotes{$symbol, $key}, $symbol, \%quotes),
+            defined $quotes{$symbol, $key}
+                ? "$key -> $quotes{$symbol, $key}"
+                : "$key -> <undefined>");
+    }
+}
+
+foreach my $symbol (keys %invalid) {
+    ok((not $quotes{'BOGUS', 'success'}), 'failed as expected');
+}
+


### PR DESCRIPTION
German Consorsbank has a Web API at https://www.consorsbank.de/web-financialinfo-service/api/marketdata/stocks? returning JSON data, which is used by this new module.

Their API provides quotes mostly from German exchanges, but e.g. LSE or NYSE appear for some more exotic papers.

Symbols have to be given as ISIN, German WKN or Consorsbank-internal ID.

Test:
```
$ ONLINE_TEST=1 dzil run prove -lv t/consorsbank.t
```