### PR TITLE
Fix for updated Bloomberg website

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -154,7 +154,7 @@
 - module: Bloomberg.pm
   state: working
   added: 
-  changed: 2022-04-17
+  changed: 2023-08-01
   removed: 
   urls: https://www.bloomberg.com/quote/
   apikey: false
@@ -165,7 +165,8 @@
     - AMZN:US
     - AAPL:US
     - GOOGL:US
-    - FB:US
+    - META:US
+    - FOLSHM1:LN
 #
 - module: Bourso.pm
   state: working

--- a/t/bloomberg.t
+++ b/t/bloomberg.t
@@ -9,7 +9,7 @@ if (not $ENV{'ONLINE_TEST'}) {
 }
 
 my $q        = Finance::Quote->new('Bloomberg');
-my @valid    = qw/MSFT:US AMZN:US AAPL:US GOOGL:US FB:US/;
+my @valid    = qw/MSFT:US AMZN:US AAPL:US GOOGL:US META:US FOLSHM1:LN/;
 my @invalid  = qw/BOGUS/;
 my @symbols  = (@valid, @invalid);
 my $year     = (localtime())[5] + 1900;


### PR DESCRIPTION
This should fix #324

The module must now use cookies to retrieve the quote data successfully. This is done using `HTTP::CookieJar::LWP`, which is a new (but small) dependency.

The module now provides the 'name' label in addition to the existing support for 'last', 'currency', 'symbol' and 'isodate'.

Conversion is also done from British pence to pounds where necessary. The associated test now includes a lookup that uses this feature.