### PR TITLE
New currencies in Stooq.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 {{$NEXT}}
 	* Stooq.pm - Added new currencies and a fix for commodities' prices
 	* YahooWeb.pm - Skip rows in the price table where the prices ar "-".
-      This seems to happen sometimes with TIAA (and perhaps other) secyrutues
-      including TILIX and QCILIX
+	  This seems to happen sometimes with TIAA (and perhaps other) secyrutues
+	  including TILIX and QCILIX
 	* TSP.pm - Was not returning hash when the HTTP GET failed completely
 	  or the content did not contain the expected CSV file. - Issue #338
 	* BSEIndia.pm - Removed print when symbol not found - Issue #335

--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Stooq.pm - Added new currencies and a fix for commodities' prices
 	* TSP.pm - Was not returning hash when the HTTP GET failed completely
 	  or the content did not contain the expected CSV file. - Issue #338
 	* BSEIndia.pm - Removed print when symbol not found - Issue #335

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 {{$NEXT}}
 	* Stooq.pm - Added new currencies and a fix for commodities' prices
-    * YahooWeb.pm - Skip rows in the price table where the prices ar "-".
+	* YahooWeb.pm - Skip rows in the price table where the prices ar "-".
       This seems to happen sometimes with TIAA (and perhaps other) secyrutues
       including TILIX and QCILIX
 	* TSP.pm - Was not returning hash when the HTTP GET failed completely

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -791,7 +791,7 @@
 - module: Stooq.pm
   state: working
   added: 2023-08-04
-  changed: ~
+  changed: 2023-08-15
   removed: ~
   urls:
     - https://stooq.com/q/?s=

--- a/lib/Finance/Quote/Stooq.pm
+++ b/lib/Finance/Quote/Stooq.pm
@@ -129,12 +129,12 @@ sub stooq {
         # except for commodities there's no A tag:
         #   commodities:     td > b[> span_with_price] + "&nbsp;_currency_without_link_"
         (my $currlink) = $table->cell(0,0) =~ m|<a href=t/(\?i=\d+)>|;
-        if ( $currencies_by_link{$currlink} ) {
+        if ( ($currlink) && ($currencies_by_link{$currlink}) ) {
           $currency = $currencies_by_link{$currlink};
         } else {
           (my $currsymbol) = $table->cell(0,0)
             =~ m|[\d\.]+</span></b>&nbsp;([^/]+)/(ozt\|lb\|t\|gal\|bbl\|bu\|mmBtu)|;
-          if ( $currencies_by_symbol{$currsymbol} ) {
+          if ( ($currsymbol) && ($currencies_by_symbol{$currsymbol}) ) {
             $currency = $currencies_by_symbol{$currsymbol};
           }
         }

--- a/lib/Finance/Quote/Stooq.pm
+++ b/lib/Finance/Quote/Stooq.pm
@@ -60,9 +60,9 @@ my %currencies_by_symbol = (
   'p.'       => "GBX", # United Kingdom (penny)
   '&euro;'   => "EUR", # Europe (€)
   'z\x{142}' => "PLN", # Poland (zł)
-  '\$'       => "USD", # United States ($)
+  '$'       => "USD", # United States ($)
   '&cent;'   => "USX", # United States (¢)
-  'HK\$'     => "HKD", # Hong Kong (HK$)
+  'HK$'     => "HKD", # Hong Kong (HK$)
   '&yen;'    => "JPY", # Japan (¥)
   'Ft'       => "HUF", # Hungary (Ft)
 );
@@ -82,7 +82,7 @@ sub stooq {
 #  my $ua = LWP::UserAgent->new(cookie_jar => $cj);
   my $ua = $quoter->user_agent();
   $ua->cookie_jar($cj);
-  $ua->default_header('Accept_Encoding' => 'deflate');
+  $ua->default_header('Accept-Encoding' => 'deflate');
   $ua->default_header('Accept-Language' => 'en-US,en;q=0.5');
 
   foreach my $stock (@stocks) {
@@ -125,15 +125,15 @@ sub stooq {
 
         # usually currency is embedded in an A tag
         #   curency default: td > b[> span_with_price] + "&nbsp;" + _a_linking_to_currency
-	#   curency USD/HUF: td > b > _a_linking_to_currency + "&nbsp;" + span_with_price
+        #   curency USD/HUF: td > b > _a_linking_to_currency + "&nbsp;" + span_with_price
         # except for commodities there's no A tag:
-	#   commodities:     td > b[> span_with_price] + "&nbsp;_currency_without_link_"
+        #   commodities:     td > b[> span_with_price] + "&nbsp;_currency_without_link_"
         (my $currlink) = $table->cell(0,0) =~ m|<a href=t/(\?i=\d+)>|;
         if ( $currencies_by_link{$currlink} ) {
           $currency = $currencies_by_link{$currlink};
         } else {
           (my $currsymbol) = $table->cell(0,0)
-            =~ m|[\d\.]+\s([^/]*)/(ozt\|lb\|t\|gal\|bbl\|bu\|mmBtu)|;
+            =~ m|[\d\.]+</span></b>&nbsp;([^/]+)/(ozt\|lb\|t\|gal\|bbl\|bu\|mmBtu)|;
           if ( $currencies_by_symbol{$currsymbol} ) {
             $currency = $currencies_by_symbol{$currsymbol};
           }
@@ -164,6 +164,11 @@ sub stooq {
               next unless ( $info{ $stock, $field } );
               $info{ $stock, $field } =
                 $quoter->scale_field( $info{ $stock, $field }, 0.01 );
+            }
+            if ( $info{ $stock, 'currency' } eq 'GBX' ) {
+              $info{ $stock, 'currency' } = 'GBP';
+            } else {
+              $info{ $stock, 'currency' } = 'USD';
             }
           }
         }

--- a/lib/Finance/Quote/Stooq.pm
+++ b/lib/Finance/Quote/Stooq.pm
@@ -138,6 +138,7 @@ sub stooq {
             $currency = $currencies_by_symbol{$currsymbol};
           }
         }
+	
         (my $date) = $table->cell(0,1) =~ m|Date.+>(\d{4}-\d{2}-\d{2})<|;
         (my $high, my $low) = $table->cell(1,1)
           =~ m|.+>([\d\.]+)<.+>([\d\.]+)<|;

--- a/lib/Finance/Quote/Stooq.pm
+++ b/lib/Finance/Quote/Stooq.pm
@@ -46,25 +46,25 @@ sub methods {
 our @labels = qw/symbol name open high low last bid ask date currency method/;
 
 my %currencies_by_link = (
-  '?i=21' => "EUR",
-  '?i=23' => "GBP",
-  '?i=25' => "HKD",
-  '?i=30' => "HUF",
-  '?i=39' => "JPY",
-  '?i=60' => "PLN",
-  '?i=77' => "USD",
+  '?i=21' => "EUR", # Europe (€)
+  '?i=23' => "GBP", # United Kingdom (£)
+  '?i=25' => "HKD", # Hong Kong (HK$)
+  '?i=30' => "HUF", # Hungary (Ft)
+  '?i=39' => "JPY", # Japan (¥)
+  '?i=60' => "PLN", # Poland (zł)
+  '?i=77' => "USD", # United States ($)
 );
 
 my %currencies_by_symbol = (
-  'p.'       => "GBX",
-  '&pound;'  => "GBP",
-  '&euro;'   => "EUR",
-  'z\x{142}' => "PLN",
-  '\$'       => "USD",
-  '&cent;'   => "USX",
-  'HK\$'     => "HKD",
-  '&yen;'    => "JPY",
-  'Ft'       => "HUF",
+  '&pound;'  => "GBP", # United Kingdom (£)
+  'p.'       => "GBX", # United Kingdom (penny)
+  '&euro;'   => "EUR", # Europe (€)
+  'z\x{142}' => "PLN", # Poland (zł)
+  '\$'       => "USD", # United States ($)
+  '&cent;'   => "USX", # United States (¢)
+  'HK\$'     => "HKD", # Hong Kong (HK$)
+  '&yen;'    => "JPY", # Japan (¥)
+  'Ft'       => "HUF", # Hungary (Ft)
 );
 
 sub labels { 
@@ -125,9 +125,9 @@ sub stooq {
 
         # usually currency is embedded in an A tag
         #   curency default: td > b[> span_with_price] + "&nbsp;" + _a_linking_to_currency
-		    #   curency USD/HUF: td > b > _a_linking_to_currency + "&nbsp;" + span_with_price
-        # except for commodities:
-		    #   commodities:     td > b[> span_with_price] + "&nbsp;_currency_without_link_"
+	#   curency USD/HUF: td > b > _a_linking_to_currency + "&nbsp;" + span_with_price
+        # except for commodities there's no A tag:
+	#   commodities:     td > b[> span_with_price] + "&nbsp;_currency_without_link_"
         (my $currlink) = $table->cell(0,0) =~ m|<a href=t/(\?i=\d+)>|;
         if ( $currencies_by_link{$currlink} ) {
           $currency = $currencies_by_link{$currlink};

--- a/lib/Finance/Quote/Stooq.pm
+++ b/lib/Finance/Quote/Stooq.pm
@@ -146,7 +146,7 @@ sub stooq {
         (my $bid) = $table->cell(4,0) =~ m|Bid.+>([\d\.]+)<|;
         (my $ask) = $table->cell(4,1) =~ m|Ask.+>([\d\.]+)<|;
         # If last and date are defined, save values in hash
-        if ( ($last) && ($date) ) {
+        if ( ($last) && ($date) && ($currency) ) {
           $info{ $stock, 'success' }  = 1;
           $info{ $stock, 'method' }   = 'stooq';
           $info{ $stock, 'name' }     = $name;


### PR DESCRIPTION
1) Currencies:
+EUR, HKD, HUF, JPY, USX
-ZAR (as unused)
2) Fix for commodities traded in:
- <span>$/</span>bbl, <span>$</span>/gal, <span>$</span>/t or <span>$</span>/mmBtu for energy commodities
- $/ozt, ¢/ozt or ¢/lb for metals
- ¢/bu or ¢/lb for grains
- $/t or ¢/lb for softs
- ¢/lb for fibers
- €/t for CO2 emission
and which don't have a currency A tag, thus no href attribute.