### PR TITLE
Skip rows in price table that don't have prices

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 {{$NEXT}}
+        * YahooWeb.pm - Skip rows in the price table where the prices ar "-".
+          This seems to happen sometimes with TIAA (and perhaps other) secyrutues
+          including TILIX and QCILIX
 	* TSP.pm - Was not returning hash when the HTTP GET failed completely
 	  or the content did not contain the expected CSV file. - Issue #338
 	* BSEIndia.pm - Removed print when symbol not found - Issue #335

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1109,7 +1109,7 @@
 - module: YahooWeb.pm
   state: working
   added: 2023-05-31
-  changed: 2023-07-16
+  changed: 2023-07-18
   removed:
   urls:
     - https://finance.yahoo.com/quote/{$symbol}?p={$symbol}

--- a/lib/Finance/Quote/YahooWeb.pm
+++ b/lib/Finance/Quote/YahooWeb.pm
@@ -60,7 +60,7 @@ sub yahooweb {
         ### YahooWeb: $url
         unless ($reply->is_success) {
             $info{ $symbol, "success" } = 0;
-            $info{ $symbol, "errmsg" } = join ' ', $reply->code, $reply->message;
+            $info{ $symbol, "errormsg" } = join ' ', $reply->code, $reply->message;
             next; 
         }
        
@@ -73,7 +73,7 @@ sub yahooweb {
         if (uc($symbol) ne uc($yahoo_symbol)) {
             ### Error: $symbol, $yahoo_symbol
             $info{ $symbol, "success" } = 0;
-            $info{ $symbol, "errmsg" } = 'Unexpected response from Yahoo site';
+            $info{ $symbol, "errormsg" } = 'Unexpected response from Yahoo site';
             next; 
         }
 
@@ -92,7 +92,7 @@ sub yahooweb {
             attribs => { 'data-test' => "historical-prices" } );
         unless ($te->parse($reply->decoded_content)) {
             $info{ $symbol, "success" } = 0;
-            $info{ $symbol, "errmsg" } = "YahooWeb - History table not found.";
+            $info{ $symbol, "errormsg" } = "YahooWeb - History table not found.";
             next;
         }
         my $historytable = $te->first_table_found();
@@ -110,7 +110,7 @@ sub yahooweb {
         ### Index: $row
         if ($row ge @$rows) {
             $info{ $symbol, "success" } = 0;
-            $info{ $symbol, "errmsg" } = "YahooWeb - no row with a price.";
+            $info{ $symbol, "errormsg" } = "YahooWeb - no row with a price.";
             next;
         }
         ### Row: $historytable->row($row)

--- a/lib/Finance/Quote/YahooWeb.pm
+++ b/lib/Finance/Quote/YahooWeb.pm
@@ -96,38 +96,55 @@ sub yahooweb {
             next;
         }
         my $historytable = $te->first_table_found();
-        ### 1st Row: $historytable->row(0)
-        my ($month, $day, $year) = $historytable->cell(0,0)
+        # Find a row with a price
+        my $row = 0;
+        foreach my $r ($historytable->rows) {
+            if (defined $historytable->cell($row, 4) &&
+                $historytable->cell($row, 4) ne "-") {
+                last;
+            }
+            $row += 1;
+        } 
+        my $rows = $historytable->rows(); 
+        ### Row count: scalar @$rows
+        ### Index: $row
+        if ($row ge @$rows) {
+            $info{ $symbol, "success" } = 0;
+            $info{ $symbol, "errmsg" } = "YahooWeb - no row with a price.";
+            next;
+        }
+        ### Row: $historytable->row($row)
+        my ($month, $day, $year) = $historytable->cell($row,0)
             =~ m|(\w+) (\d+), (\d{4})|;
         ### Month: $month
         ### Day: $day
         ### Year: $year
 
-        my $last = $historytable->cell(0,4);
+        my $last = $historytable->cell($row,4);
         $last =~ s/,//g;
         if ($currency =~ /^GBp/) {
             $last = $last / 100;
         }
 
-        my $open = $historytable->cell(0,1);
+        my $open = $historytable->cell($row,1);
         $open =~ s/,//g;
         if ($currency =~ /^GBp/) {
             $open = $open / 100;
         }
 
-        my $high = $historytable->cell(0,2);
+        my $high = $historytable->cell($row,2);
         $high =~ s/,//g;
         if ($currency =~ /^GBp/) {
             $high = $high / 100;
         }
 
-        my $low = $historytable->cell(0,3);
+        my $low = $historytable->cell($row,3);
         $low =~ s/,//g;
         if ($currency =~ /^GBp/) {
             $low = $low / 100;
         }
 
-        my $volume = $historytable->cell(0,6);
+        my $volume = $historytable->cell($row,6);
         $volume =~ s/,//g;
 
         ### YahooWeb Result: $last

--- a/lib/Finance/Quote/YahooWeb.pm
+++ b/lib/Finance/Quote/YahooWeb.pm
@@ -152,7 +152,7 @@ sub yahooweb {
         $info{ $symbol, 'open'} = $open;
         $info{ $symbol, 'high'} = $high;
         $info{ $symbol, 'low'} = $low;
-        $info{ $symbol, 'volume'} = $volume;
+        $info{ $symbol, 'volume'} = $volume unless $volume eq "-";
 
         $quoter->store_date(\%info, $symbol, {month => $month, day => $day, year => $year});   
         $info{ $symbol, 'symbol' } = $symbol;

--- a/lib/Finance/Quote/YahooWeb.pm
+++ b/lib/Finance/Quote/YahooWeb.pm
@@ -108,7 +108,7 @@ sub yahooweb {
         my $rows = $historytable->rows(); 
         ### Row count: scalar @$rows
         ### Index: $row
-        if ($row ge @$rows) {
+        if ($row >= @$rows) {
             $info{ $symbol, "success" } = 0;
             $info{ $symbol, "errormsg" } = "YahooWeb - no row with a price.";
             next;


### PR DESCRIPTION
The YahooWeb interface sometimes returns tables that have rows with no prices.  Skip them and find the first row with prices. One security that shows this problem is TILIX.