### PR TITLE
Fix scraper in Finanzpartner.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@
 	* TSP.pm - Was not returning hash when the HTTP GET failed completely
 	  or the content did not contain the expected CSV file. - Issue #338
 	* BSEIndia.pm - Removed print when symbol not found - Issue #335
+	* Finanzpartner.pm - Fix scraper, did not work if quote was higher than the previous day's quote.
 
 1.58      2023-08-12 10:59:05-07:00 America/Los_Angeles
 	* Consorsbank.pm - New module - PR #329

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -430,15 +430,18 @@
   testcases:
 #
 - module: Finanzpartner.pm
-  state: TBD
+  state: working
   added: TBD
-  changed: ~
+  changed: 2023-11-27
   removed: ~
-  urls:
+  urls: https://www.finanzpartner.de/fi/
   apikey: false
   notes: ~
-  testfile: TBD
+  testfile: finanzpartner.t
   testcases:
+   - "LU0293315023", 
+   - "LU0856992614", 
+   - "LU1720050803".
 #
 - module: Fool.pm
   state: working

--- a/lib/Finance/Quote/Finanzpartner.pm
+++ b/lib/Finance/Quote/Finanzpartner.pm
@@ -63,12 +63,18 @@ sub finanzpartner
 
       my $processor = scraper {
         process 'span.kurs-m.pull-left', 'price[]' => 'TEXT';
+        process 'span.kurs.pull-left', 'price_alternative[]' => 'TEXT';
         process 'h1 > small', 'isin[]'             => 'TEXT';
         process 'div.col-md-2', 'date[]'           => 'TEXT';
         process 'h1 > span', 'name[]'              => 'TEXT';
       };
  
       my $data = $processor->scrape(decode_utf8 $reply->content);
+
+      # If price does not exists, then price_alternative should exist. In that case, put price_alternative into price.
+      if(exists $data->{price_alternative}) {
+        $data->{price} = $data->{price_alternative};
+      }
 
       ### data: $data
       

--- a/t/finanzpartner.t
+++ b/t/finanzpartner.t
@@ -17,7 +17,7 @@ my $year = (localtime())[5] + 1900;
 my $lastyear = $year - 1;
 my $q      = Finance::Quote->new("Finanzpartner");
 
-my %quotes = $q->finanzpartner("LU0293315023", "BOGUS");
+my %quotes = $q->finanzpartner("LU0293315023", "BOGUS", "LU0856992614", "LU1720050803");
 ok(%quotes);
 
 ### quotes : %quotes
@@ -31,6 +31,24 @@ ok(substr($quotes{"LU0293315023","isodate"},0,4) == $year ||
 ok(substr($quotes{"LU0293315023","date"},6,4) == $year ||
     substr($quotes{"LU0293315023","date"},6,4) == $lastyear);
 ok($quotes{"LU0293315023","currency"} eq "EUR");
+
+ok($quotes{"LU0856992614","success"});
+ok($quotes{"LU0856992614","last"} > 0);
+ok(length($quotes{"LU0856992614","date"}) > 0);
+ok(substr($quotes{"LU0856992614","isodate"},0,4) == $year ||
+    substr($quotes{"LU0856992614","isodate"},0,4) == $lastyear);
+ok(substr($quotes{"LU0856992614","date"},6,4) == $year ||
+    substr($quotes{"LU0856992614","date"},6,4) == $lastyear);
+ok($quotes{"LU0856992614","currency"} eq "EUR");
+
+ok($quotes{"LU1720050803","success"});
+ok($quotes{"LU1720050803","last"} > 0);
+ok(length($quotes{"LU1720050803","date"}) > 0);
+ok(substr($quotes{"LU1720050803","isodate"},0,4) == $year ||
+    substr($quotes{"LU1720050803","isodate"},0,4) == $lastyear);
+ok(substr($quotes{"LU1720050803","date"},6,4) == $year ||
+    substr($quotes{"LU1720050803","date"},6,4) == $lastyear);
+ok($quotes{"LU1720050803","currency"} eq "USD");
 
 # Check that a bogus fund returns non-success.
 ok($quotes{"BOGUS","success"} == 0);

--- a/t/finanzpartner.t
+++ b/t/finanzpartner.t
@@ -11,7 +11,7 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 8;
+plan tests => 20;
 
 my $year = (localtime())[5] + 1900;
 my $lastyear = $year - 1;


### PR DESCRIPTION
The parsing of Finanzpartner page sometimes fails because the current parser only works if the current quote is less than the previous day's quote.  This fix checks for both cases and uses the correct value.