### PR TITLE
Minor change to TwelveData.pm - Add "last"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* TwelveData.pm - Added "last" to data being returned
 	* BorsaItaliana.pm - New module for Borsa Italiana, Italian traded bonds using ISIN
 	* YahooWeb.pm - Issue #377. Modified YahooWeb to account for changes from Yahoo.
 

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1031,7 +1031,7 @@
 - module: TwelveData.pm
   state: working
   added: 2023-05-26
-  changed: 2023-05-31
+  changed: 2024-04-25
   removed:
   urls:
     - https://api.twelvedata.com/quote?symbol={$symbol}&apikey={$token}

--- a/lib/Finance/Quote/TwelveData.pm
+++ b/lib/Finance/Quote/TwelveData.pm
@@ -41,7 +41,7 @@ sub parameters {
 }
 
 {
-    our @labels = qw/symbol name exchange currency isodate currency open high low close/;
+    our @labels = qw/symbol name exchange currency isodate currency open high low close last/;
 
     sub labels {
         return ( twelvedata => \@labels );
@@ -123,6 +123,7 @@ sub twelvedata {
         $info{ $symbol, 'high' }    = $quote->{'high'} if $quote->{'high'};
         $info{ $symbol, 'low' }     = $quote->{'low'} if $quote->{'low'};
         $info{ $symbol, 'close' }   = $quote->{'close'} if $quote->{'close'};
+        $info{ $symbol, 'last' }   = $quote->{'close'} if $quote->{'close'};
         $info{ $symbol, 'volume' }  = $quote->{'volume'} if $quote->{'volume'};
         $info{ $symbol, 'method' }  = 'twelvedata';
        
@@ -183,6 +184,6 @@ The TwelveData free key limits usage to:
 =head1 LABELS RETURNED
 
 The following labels may be returned by Finance::Quote::TwelveData :
-    symbol name exchange currency isodate currency open high low close
+    symbol name exchange currency isodate currency open high low close last
 
 =cut


### PR DESCRIPTION
Hash returned by TwelveData.pm did not return `last` or `price` and would not be used by GnuCash. Added `last` (copy of `close`) to data returned.