### PR TITLE
AlphaVantage - Remove Throttling

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Removed throttling from AlphaVantage.pm - Issue #363
 	* Added CurrencyFreaks.pm - new currency module
 	* YahooJSON.pm - added more error handling - Issue #390
 	* Fixed MarketWatch.pm module - Issue #389

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -73,7 +73,7 @@
 - module: AlphaVantage.pm
   state: working
   added:
-  changed: 2023-07-28
+  changed: 2024-04-07
   removed:
   urls:
     - https://www.alphavantage.co/query?function=GLOBAL_QUOTE&apikey=$ALPHAVANTAGE_API_KEY&symbol=
@@ -85,29 +85,15 @@
     return a currency.
   testfile: alphavantage.t
   testcases:
-    - IBM
+    - BP.L
     - CSCO
-    - SOLB.BR
-    - SAP.DE
-    - TD.TO
-    - LSE.L
-    - VFIAX
-    - T
     - DIVO11.SA
-    - OGZD.IL
-    - TWTR
-    - AAPL
-    - ORCL
-    - CMCSA
-    - INTC
-    - NFLX
-    - TSLA
-    - NOK
-    - BAC
-    - GOOG
-    - F
-    - AXP
-    - ERIC-B.STO
+    - ERCB.DE
+    - IBM
+    - MRT-UN.TRT
+    - SAP.DE
+    - SOLB.BR
+    - TD.TO
 #
 - module: BMONesbittBurns.pm
   state: failing

--- a/README.md
+++ b/README.md
@@ -530,7 +530,6 @@ http://www.gnucash.org/
 # SEE ALSO
 
     Finance::Quote::CurrencyRates::AlphaVantage,
-    Finance::Quote::CurrencyRates::CurrencyFreaks,
     Finance::Quote::CurrencyRates::ECB,
     Finance::Quote::CurrencyRates::Fixer,
     Finance::Quote::CurrencyRates::OpenExchange,

--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -16,6 +16,9 @@
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #    02110-1301, USA
 
+# 2024-04-07: Commented call to sleep_before_query in get_content
+#             subroutine. AlphaVantage is not throttling API calls,
+#             but limits usage with free API key to 25 per day.
 # 2019-12-01: Added additional labels for net and p_change. Set
 #             close to previous close as returned in the JSON.
 #             Bruce Schuck (bschuck at asgard hyphen systems dot com)
@@ -207,7 +210,7 @@ sub alphavantage {
             . $ticker;
 
         my $get_content = sub {
-            sleep_before_query();
+            # sleep_before_query();
             my $time=int(time()-$launch_time);
             # print STDERR "Query at:".$time."\n";
             $reply = $ua->request( GET $url);

--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -125,7 +125,7 @@ sub yahoo_json {
     # get necessary cookies
     $reply = $ua->get('https://www.yahoo.com/', "Accept" => "text/html");
     if ($reply->code != 200) {
-        foreach $symbol (@stocks) {
+        foreach my $symbol (@stocks) {
             $info{$symbol, "success"} = 0;
             $info{$symbol, "errormsg"} = "Error accessing www.yahoo.com: $@";
         }     
@@ -135,7 +135,7 @@ sub yahoo_json {
     # get the crumb that corrosponds to cookies retrieved
     $reply = $ua->request(GET 'https://query2.finance.yahoo.com/v1/test/getcrumb');
     if ($reply->code != 200) {
-        foreach $symbol (@stocks) {
+        foreach my $symbol (@stocks) {
             $info{$symbol, "success"} = 0;
             $info{$symbol, "errormsg"} = "Error accessing queary.finance.yahoo.com/v1/test/getcrumb: $@";
         }     

--- a/t/alphavantage.t
+++ b/t/alphavantage.t
@@ -17,29 +17,15 @@ my $year     = ( localtime() )[5] + 1900;
 my $lastyear = $year - 1;
 
 my @symbols = qw/
-    IBM
-    CSCO
-    SOLB.BR
-    SAP.DE
-    TD.TO
-    VFIAX
-    T
-    DIVO11.SA
-    TWTR
-    AAPL
-    ORCL
-    CMCSA
-    INTC
-    NFLX
-    TSLA
-    NOK
-    BAC
-    GOOG
-    F
-    AXP
-    ERCB.DE
-    MRT-UN.TRT
     BP.L
+    CSCO
+    DIVO11.SA
+    ERCB.DE
+    IBM
+    MRT-UN.TRT
+    SAP.DE
+    SOLB.BR
+    TD.TO
 /;
 
 plan tests => 1 + 11*(1+$#symbols) + 10;
@@ -63,14 +49,14 @@ foreach my $symbol (@symbols) {
                || substr( $quotes{ $symbol, "date" }, 6, 4 ) == $lastyear );
 }
 
-is( $quotes{ "IBM", "currency" }, 'USD' );
-is( $quotes{ "CSCO", "currency" }, 'USD' );
-is( $quotes{ "ERCB.DE", "currency" }, 'EUR' );
-is( $quotes{ "SOLB.BR", "currency" }, 'EUR' );
-is( $quotes{ "SAP.DE", "currency" }, 'EUR' );
-is( $quotes{ "TD.TO", "currency" }, 'CAD' );
-is( $quotes{ "MRT-UN.TRT", "currency" }, 'CAD' );
 is( $quotes{ "BP.L", "currency" }, 'GBP' );
+is( $quotes{ "CSCO", "currency" }, 'USD' );
 is( $quotes{ "DIVO11.SA", "currency" }, 'BRL' );
+is( $quotes{ "ERCB.DE", "currency" }, 'EUR' );
+is( $quotes{ "IBM", "currency" }, 'USD' );
+is( $quotes{ "MRT-UN.TRT", "currency" }, 'CAD' );
+is( $quotes{ "SAP.DE", "currency" }, 'EUR' );
+is( $quotes{ "SOLB.BR", "currency" }, 'EUR' );
+is( $quotes{ "TD.TO", "currency" }, 'CAD' );
 
 ok( !$quotes{ "BOGUS", "success" } );


### PR DESCRIPTION
This PR removes throttling in the AlphaVantage.pm module. While AlphaVantage now limits the free API usage to 25 per day, there is no throttling enforced. 

Additionally, the number of symbols checked in the `t/alphavantage.t` test script has been reduced to 9.