### PR TITLE
Fixes #410 (NSEIndia.pm and BSEIndia.pm) - Pull Request

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 {{$NEXT}}
-	* Fixed NZX.pm - Issue #401
 	* Fixed BSEIndia.pm - Issue #410 and removed Unzip as quotes file is now a CSV file
 	* Fixed NSEIndia.pm - Issue #410
+	* Fixed NZX.pm - Issue #401
 
 1.62      2024-05-16 18:19:12-07:00 America/Los_Angeles
 	* Fixed AEX.pm

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 	* Fixed NZX.pm - Issue #401
+	* Fixed BSEIndia.pm - Issue #410 and removed Unzip as quotes file is now a CSV file
+	* Fixed NSEIndia.pm - Issue #410
 
 1.62      2024-05-16 18:19:12-07:00 America/Los_Angeles
 	* Fixed AEX.pm

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -121,10 +121,10 @@
 - module: BSEIndia.pm
   state: working
   added: 2020-06-27
-  changed: 2023-12-27
+  changed: 2024-07-30
   removed:
   urls:
-    - https://www.bseindia.com/download/BhavCopy/Equity/BSE_EQ_BHAVCOPY_{DDMMYYYY}.ZIP
+	- https://www.bseindia.com/download/BhavCopy/Equity/BhavCopy_BSE_CM_0_0_0_{YYYYMMDD}_F_0000.CSV
   methods:
     - india
     - bseindia
@@ -736,10 +736,10 @@
 - module: NSEIndia.pm
   state: working
   added: 2020-06-27
-  changed: 2024-01-12
+  changed: 2024-07-30
   removed:
   urls:
-    - https://archives.nseindia.com/content/historical/EQUITIES/${YYYY}/${MMM}/cm${DDMMMYYYY}bhav.csv.zip
+	- https://nsearchives.nseindia.com/content/cm/BhavCopy_NSE_CM_0_0_0_{YYYYMMDD}_F_0000.csv.zip
   methods:
     - india
     - nseindia


### PR DESCRIPTION
## NAME
**NSEIndia.pm** is an existing Perl module in Finance::Quotes. It retrieves stocks / securities prices from the NSE India website at https://www.nseindia.com.
**BSEIndia.pm** is an existing Perl module in Finance::Quotes. It retrieves stocks prices from the BSE India website at https://www.bseindia.com.

Change in the URL of the data file and it's format to UDiFF broke quotes updates from NSEIndia.pm and BSEIndia.pm.

## WHY THIS CHANGE
Issue #410 was logged due to the **NSEIndia.pm** CSV file format being changed. This change resolves the Issue #410 that impacted NSEIndia.pm. The change was to the folder, the file and the format of the contents of the CSV file released daily by nseindia.com.

It was found that Issue #410 also impacted **BSEIndia.pm**. This change resolves Issue #410 in BSEIndia.pm also.The change was to the folder, the file and the format of the contents of the CSV file released daily by bseindia.com.

## DEVELOPMENT TOOLS USED
NSEIndia.pm and BSEIndia.pm modules are Perl code that aligns with Finance::Quote hackers guide. Code editor of choice was Geany on Linux which is available at https://www.geany.org/. vscode can be used too, but why use something much more bigger in size :-).

The finance-quote repository was forked to https://github.com/bgr22112/finance-quote

## FILES MODIFIED
### NSEIndia.pm
- Changed to resolve issue #410 that broke the retrieval of daily stock quotes from nseindia.com.
- URL is https://nsearchives.nseindia.com/content/cm/BhavCopy_NSE_CM_0_0_0_20240718_F_0000.csv.zip
- Users can use ISIN or TckrSymb as security code.

### BSEIndia.pm
- Changed to resolve issue #410 that broke the retrieval of daily stock quotes from bseindia.com.
- URL is https://www.bseindia.com/download/BhavCopy/Equity/BhavCopy_BSE_CM_0_0_0_20240718_F_0000.CSV
- Users can use ISIN or BSE Symbol code as security code.

### Modules-README.yml
- Modified the date with the date when the change was done to NSEIndia.pm and BSEIndia.pm.

### Changes
- Added a summary of the change done to NSEIndia.pm.
- Added a summary of the change done to BSEIndia.pm.

## TESTS
nseindia.t - Existing test for NSEIndia, which were successfully completed.
bseindia.t - Existing test for BSEindia, which were successfully completed.

## CODE BREAKDOWN
### NSEIndia.pm
1. Changed the URL of the file to be retrieved from nseindia website.
2. Changed headers used to identify columns to be updated.
3. Changed from eurodate to isodate to convert TradDt using in-built store_date function.

### BSEIndia.pm
1. Changed the URL of the file to be retrieved from nseindia website.
2. File from URL does not need unzipping. Removed unzip.
3. Changed headers used to identify columns to be updated.
4. Changed from eurodate to isodate to convert TradDt using in-built store_date function.

That's all.

## TEST CASES
testfile:
- nseindia.t
- bseindia.t

## COPYRIGHT & LICENCE
This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.

Currency and stock price information fetched through this module is bound by the terms and conditions of the data source.

Other copyrights and conditions may apply to data fetched through this module. Please refer to the sub-modules for further information.

## AUTHORS
Rajan Vaswani (www.askmeaboutlinux.com)