### PR TITLE
FinanceAPI.pm - New Module

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Added FinanceAPI.pm - Requires API key from https://financeapi.net/. US and other exchange data available.
 	* Fixed BVB.pm - Issue #409
 	* Fixed BSEIndia.pm - Issue #410 and removed Unzip as quotes file is now a CSV file
 	* Fixed NSEIndia.pm - Issue #410

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -392,6 +392,30 @@
     - DE0008474511
     - LU0051755006
 #
+- module: FinanceAPI.pm
+  state: working
+  added: 2024-09-01
+  changed: ~
+  removed: ~
+  urls:
+    - https://financeapi.net/
+    - https://yfapi.net/v6/finance/quote?
+  methods:
+    - financeapi
+    - nasdaq
+    - nyse
+    - usa
+  apikey: true
+  notes: |
+    The API token can be passed in when the quote object is created
+    or read from the environment variable FINANCEAPI_API_KEY.
+  testfile: financeapi.t
+  testcases:
+    - MSFT
+    - IBM
+    - F
+    - GE
+#
 - module: Fondsweb.pm
   state: working
   added: TBD

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -73,10 +73,11 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     Currencies
     DWS
     Deka
-    FTfunds
+    FinanceAPI
     Finanzpartner
     Fondsweb
     Fool
+    FTfunds
     GoldMoney
     GoogleWeb
     HU
@@ -1696,10 +1697,11 @@ http://www.gnucash.org/
   Finance::Quote::Currencies,
   Finance::Quote::DWS,
   Finance::Quote::Deka,
-  Finance::Quote::FTfunds,
+  Finance::Quote::FinanceAPI,
   Finance::Quote::Finanzpartner,
   Finance::Quote::Fondsweb,
   Finance::Quote::Fool,
+  Finance::Quote::FTfunds,
   Finance::Quote::GoldMoney,
   Finance::Quote::GoogleWeb,
   Finance::Quote::HU,

--- a/lib/Finance/Quote/FinanceAPI.pm
+++ b/lib/Finance/Quote/FinanceAPI.pm
@@ -148,6 +148,8 @@ sub financeapi {
 
       # Check for stocks traded in pence instead of pounds
       # Convert GBp or GBX to GBP (divide price by 100).
+      # GBP.L - pence
+      # GBPG.L - pounds
 
       if ( ($info{$stock,"currency"} eq "GBp") ||
          ($info{$stock,"currency"} eq "GBX")) {

--- a/lib/Finance/Quote/FinanceAPI.pm
+++ b/lib/Finance/Quote/FinanceAPI.pm
@@ -1,0 +1,236 @@
+#!/usr/bin/perl -w
+# vi: set ts=2 sw=2 noai ic showmode showmatch:  
+#
+#    Copyright (C) 2024, Bruce Schuck <bschuck@asgard-systems.com>
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#    02110-1301, USA
+
+#    Changes:
+#    Initial Version: 2024-08-31, Bruce Schuck
+
+package Finance::Quote::FinanceAPI;
+
+use strict;
+use warnings;
+
+use Encode qw(decode);
+use HTTP::Request::Common;
+use JSON qw( decode_json );
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments', '###';
+
+# VERSION
+
+my $FINANCEAPI_URL = 'https://yfapi.net/v6/finance/quote?region=US&lang=en&symbols=';
+
+# Change DISPLAY and method values in code below
+# Modify LABELS to those returned by the method
+
+our $DISPLAY    = 'FinanceAPI';
+our $FEATURES   = {'API_KEY' => 'registered user API key'};
+our @LABELS     = qw/symbol name open high low last date volume currency method/;
+our $METHODHASH = {subroutine => \&financeapi>, 
+                   display => $DISPLAY, 
+                   labels => \@LABELS,
+                   features => $FEATURES};
+
+sub methodinfo {
+    return ( 
+        <method> => $METHODHASH,
+        nyse         => $METHODHASH,
+        nasdaq       => $METHODHASH,
+        usa          => $METHODHASH,
+    );
+}
+
+sub labels { my %m = methodinfo(); return map {$_ => [@{$m{$_}{labels}}] } keys %m; }
+
+sub methods {
+  my %m = methodinfo(); return map {$_ => $m{$_}{subroutine} } keys %m;
+}
+
+sub financeapi {
+
+  my $quoter = shift;
+  my @stocks = @_;
+  my (%info, $url, $reply);
+  my $ua = $quoter->user_agent();
+
+  # Set token. If not passed in as argument, get from environment.
+  my $token = exists $quoter->{module_specific_data}->{stockdata}->{API_KEY} ? 
+              $quoter->{module_specific_data}->{stockdata}->{API_KEY}        :
+              $ENV{"FINANCE_API_KEY"};
+
+  # Set headers. API key is sent as a header.
+  my @ua_headers = (
+    'Accept' => 'application/json',
+    'X-API-KEY' => $token,
+  );
+
+  foreach my $stock (@stocks) {
+
+    $url   = $FINANCEAPI_URL . $stock;
+    $reply = $ua->get( $url, @ua_headers );
+
+    my $code    = $reply->code;
+    my $desc    = HTTP::Status::status_message($code);
+    my $headers = $reply->headers_as_string;
+    my $body    = decode('UTF-8', $reply->content);
+
+    ### Body: $body
+
+    my ($name, $bid, $ask, $last, $open, $high, $low, $date);
+
+    $info{ $stock, "symbol" } = $stock;
+
+    if ( $code == 200 ) {
+
+      # Use HTML::TreeBuilder to parse HTML in $body
+      $tree = HTML::TreeBuilder->new;
+      if ($tree->parse($body)) {
+
+        $tree->eof;
+        if ( $tree->look_down(_tag => 'div', id => 'ctl00_body_divNoData') ) {
+          $info{ $stock, "success" } = 0;
+          $info{ $stock, "errormsg" } =
+            "Error retrieving quote for $stock. No data returned";
+          next;
+        }
+        $name = $tree->look_down(_tag => 'h2', class => qr/^mBot0 large textStyled/)->as_text;
+        $info{ $stock, 'success' } = 1;
+        ($info{ $stock, 'name' } = $name) =~ s/^\s+|\s+$//g ;
+        $info{ $stock, 'currency' } = 'RON';
+        $info{ $stock, 'method' } = 'bvb';
+        $table = $tree->look_down(_tag => 'table', id => qr/^ctl00_body_ctl02_PricesControl_dvCPrices/)->as_HTML;
+        $pricetable = HTML::TableExtract->new();
+        $pricetable->parse($table);
+        foreach my $row ($pricetable->rows) {
+          if ( @$row[0] =~ m/Ask$/ ) {
+            ($bid, $ask) = @$row[1] =~ m|^\s+([\d\.]+)\s+\/\s+([\d\.]+)|;
+            $info{ $stock, 'bid' } = $bid;
+            $info{ $stock, 'ask' } = $ask;
+          }
+          elsif ( @$row[0] =~ m|^Date/time| ) {
+            ($date) = @$row[1] =~ m|^([\d/]+)\s|;
+            $quoter->store_date(\%info, $stock, {usdate => $1}) if $date =~ m|([0-9]{1,2}/[0-9]{2}/[0-9]{4})|;
+          }
+          elsif ( @$row[0] =~ m|^Last price| ) {
+            ($last) = @$row[1] =~ m|^([\d\.]+)|;
+            $info{ $stock, 'last' } = $last;
+          }
+          elsif ( @$row[0] =~ m|^Open price| ) {
+            ($open) = @$row[1] =~ m|^([\d\.]+)|;
+            $info{ $stock, 'open' } = $open;
+          }
+          elsif ( @$row[0] =~ m|^High price| ) {
+            ($high) = @$row[1] =~ m|^([\d\.]+)|;
+            $info{ $stock, 'high' } = $high;
+          }
+          elsif ( @$row[0] =~ m|^Low price| ) {
+            ($low) = @$row[1] =~ m|^([\d\.]+)|;
+            $info{ $stock, 'low' } = $low;
+          }
+        }
+
+      } else {
+        $tree->eof;
+        $info{ $stock, "success" } = 0;
+        $info{ $stock, "errormsg" } =
+          "Error retrieving quote for $stock. Could not parse HTML returned from $url.";
+      }
+
+    } else {       # HTTP Request failed (code != 200)
+      $info{ $stock, "success" } = 0;
+      $info{ $stock, "errormsg" } =
+        "Error retrieving quote for $stock. Attempt to fetch the URL $url resulted in HTTP response $code ($desc)";
+    }
+
+  }  
+
+  return wantarray() ? %info : \%info;
+  return \%info;
+
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Finance::Quote::FinanceAPI - Obtain quotes from financeapi.net.
+
+=head1 SYNOPSIS
+
+    use Finance::Quote;
+
+    # API Key passed during object creation
+    $q = Finance::Quote->new('FinanceAPI', financeapi => {API_KEY => 'your-financeapi-api-key'});
+
+    # FINANCEAPI_API_KEY environment variable set
+    $q = Finance::Quote->new;
+
+    %info = $q->fetch("financeapi", "AAPL");  # Only query financeapi
+
+=head1 DESCRIPTION
+
+This module fetches information from L<https://financeapi.net/>. The API URL
+is https://yfapi.net/.
+
+This module is loaded by default on a Finance::Quote object. It's also possible
+to load it explicitly by placing "financeapi" in the argument list to
+Finance::Quote->new().
+
+This module provides the "financeapi" fetch method. In addition it
+advertises "nyse", "usa", and "nasdaq".
+
+=head1 API_KEY
+
+L<https://financeapi.net/> requires users to register for an API Key
+(token).
+
+The API key may be set by either providing a module specific hash to
+Finance::Quote->new as in the above example, or by setting the environment
+variable FINANCEAPI_API_KEY.
+
+=head1 LABELS RETURNED
+
+The following labels are returned: 
+
+=over
+
+=item name
+
+=item symbol
+
+=item open
+
+=item high
+
+=item low
+
+=item price
+
+=item bid
+
+=item ask
+
+=item date
+
+=item currency
+
+=back

--- a/t/financeapi.t
+++ b/t/financeapi.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use Test::More;
+use Finance::Quote;
+use Date::Simple qw(today);
+use Scalar::Util qw(looks_like_number);
+use Date::Range;
+use Date::Manip;
+
+if (not $ENV{ONLINE_TEST}) {
+    plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
+}
+
+my @valid    = qw/MSFT IBM F GE/;
+my @invalid  = ('BOGUS');
+my @symbols  = (@valid, @invalid);
+
+my $q        = Finance::Quote->new('FinanceAPI', timeout => 120);
+my $today    = today();
+my $window   = 7;
+
+my %check    = (# Tests are called with (value_to_test, symbol, quote_hash_reference)
+                'success'  => sub {$_[0] == 1},
+                'symbol'   => sub {$_[0] eq $_[1]},
+                'last'     => sub {looks_like_number($_[0])},
+                'isodate'  => sub {Date::Range->new($today - $window, $today)->includes(Date::Simple::ISO->new($_[0]))},
+               );
+
+plan tests => 1 + %check*@valid + @invalid;
+
+my %quotes = $q->yahooweb(@symbols);
+ok(%quotes);
+
+### [<now>] quotes: %quotes
+
+foreach my $symbol (@valid) {
+  while (my ($key, $lambda) = each %check) {
+    ok($lambda->($quotes{$symbol, $key}, $symbol, \%quotes), "$key -> " . (defined $quotes{$symbol, $key} ? $quotes{$symbol, $key} : '<undefined>'));
+  }
+}
+    
+foreach my $symbol (@invalid) {
+  ok((not $quotes{'BOGUS', 'success'}), 'failed as expected');
+}
+


### PR DESCRIPTION
FinanceAPI.pm is new module. See https://financeapi.net/. An API Key is required. The URL used by the `financeapi` method is https://yfapi.net/v6/finance/quote?. 
Data is available from US and other exchanges. The free basic API Key allows 100 queries per day rate limited to 300 per minute.
It provides for the multiple/failover methods "nyse", "nasdaq", and "usa".