### PR TITLE
Fix TesouroDireto module

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Fixed TesouroDireto.pm - Using different source URL - PR #424
 	* Added FinanceAPI.pm - Requires API key from https://financeapi.net/. US and other exchange data available.
 	* Fixed BVB.pm - Issue #409
 	* Fixed BSEIndia.pm - Issue #410 and removed Unzip as quotes file is now a CSV file

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1086,15 +1086,16 @@
 - module: TesouroDireto.pm
   state: working
   added: 2022-02-06
-  changed: ~
+  changed: 2024-09-11
   removed: ~
   urls:
     - https://www.tesourodireto.com.br/titulos/precos-e-taxas.htm
+    - https://github.com/ghostnetrn/bot-tesouro-direto
   apikey: false
   notes: ~
   testfile: tesouro_direto.t
   testcases:
-    - Tesouro Prefixado 2026
+    - Tesouro Prefixado 2031
     - Tesouro IPCA+ 2045
 #
 - module: TreasuryDirect.pm

--- a/lib/Finance/Quote/TesouroDireto.pm
+++ b/lib/Finance/Quote/TesouroDireto.pm
@@ -44,9 +44,6 @@ sub tesouro
 
   my $ua = $quoter->user_agent;
 
-  # Bad stuff to get around bad cert and ssl confs
-  $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0, SSL_cipher_list => 'DEFAULT:!DH');
-
   my (%fundsymbol, %fundhash, @q, %info);
 
   # create hash of all funds requested
@@ -55,7 +52,7 @@ sub tesouro
       $fundhash{$fund} = 0;
   }
 
-  my $url = "https://www.tesourodireto.com.br/json/br/com/b3/tesourodireto/service/api/treasurybondsinfo.json";
+  my $url = "https://raw.githubusercontent.com/ghostnetrn/bot-tesouro-direto/main/tesouro.json";
   my $response = $ua->request(GET $url);
 
   if ($response->is_success) {

--- a/t/tesouro_direto.t
+++ b/t/tesouro_direto.t
@@ -7,7 +7,7 @@ if ( not $ENV{"ONLINE_TEST"} ) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-my @bounds = ("Tesouro Prefixado 2026", "Tesouro IPCA+ 2045");
+my @bounds = ("Tesouro Prefixado 2031", "Tesouro IPCA+ 2045");
 
 plan tests => 1 + 8*(1+$#bounds) + 1;
 


### PR DESCRIPTION
As the official site https://tesourodireto.gov.br started using CloudFlare, switch to an (unofficial) mirror of the bound data hosted on github as data source.

Updated the test file from a bound due on 2026 to another due on 2031 to delay having to change it later.