### PR TITLE
Allow API_KEYs from Environment Variables in Fixer.pm and OpenExchange.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Allowed Currency Rates modules Fixer.pm and OpenExchange.pm to read their API keys from environment variables - Issue #426
 
 1.63      2024-09-21 12:47:39-07:00 America/Los_Angeles
 	* Fixed TesouroDireto.pm - Using different source URL - PR #424

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -348,6 +348,41 @@
     - AUD AUD
     - INR INR
 #
+- module: CurrencyRates/Fixer.pm
+  state: working
+  Added: TBD
+  changed: 2024-09-21
+  removed: ~
+  urls: http://data.fixer.io/api/latest?access_key=$this->{API_KEY}
+  apikey: true
+  notes: |
+    Modified to allow FIXER_API_KEY environment variable.
+    Running test file requires TEST_FIXER_API_KEY environment variable
+  testfile: currency.t
+  testcases:
+    - USD EUR
+    - GBP IDR
+    - IDR CAD
+    - AUD AUD
+#
+- module: CurrencyRates/OpenExchange.pm
+  state: working
+  Added: TBD
+  changed: 2024-09-21
+  removed: ~
+  urls: https://openexchangerates.org/api/latest.json?app_id=$this->{API_KEY}
+  apikey: true
+  notes: |
+    Modified to allow OpenExchange_API_KEY environment variable.
+    Running test file requires TEST_OPENEXCHANGE_API_KEY environment variable
+    set.
+  testfile: currency-openexchange.t
+  testcases:
+    - USD EUR
+    - GBP IDR
+    - IDR CAD
+    - AUD AUD
+#
 - module: CurrencyRates/YahooJSON.pm
   state: working
   Added: 2023-04-09

--- a/lib/Finance/Quote/CurrencyRates/Fixer.pm
+++ b/lib/Finance/Quote/CurrencyRates/Fixer.pm
@@ -43,11 +43,16 @@ sub new
 
   ### Fixer->new args : $args
 
-  return unless (ref $args eq 'HASH') and (exists $args->{API_KEY});
+  $this->{API_KEY} = $ENV{'FIXER_API_KEY'};
 
-  $this->{API_KEY} = $args->{API_KEY};
+  $this->{API_KEY} = $args->{API_KEY} if (ref $args eq 'HASH') and (exists $args->{API_KEY});
   $this->{refresh} = 0;
   $this->{refresh} = not $args->{cache} if exists $args->{cache};
+
+  # Return nothing if API_KEY not set
+  return unless ($this->{API_KEY});
+
+  ### API_KEY: $this->{API_KEY}
 
   return $this;
 }
@@ -114,7 +119,7 @@ unless 'cache => 0' is included in the 'fixer' options hash.
 
 https://fixer.io requires users to register and obtain an API key.  
 
-The API key must be set by providing a 'fixer' hash inside the 'currency_rates'
+The API key can be set by setting the Environment variable "FIXER_API_KEY" or providing a 'fixer' hash inside the 'currency_rates'
 hash to Finance::Quote->new as in the above example.
 
 =head1 Terms & Conditions

--- a/lib/Finance/Quote/CurrencyRates/OpenExchange.pm
+++ b/lib/Finance/Quote/CurrencyRates/OpenExchange.pm
@@ -43,14 +43,21 @@ sub new
 
   ### OpenExchange->new args : $args
 
-  return unless (ref $args eq 'HASH') and (exists $args->{API_KEY});
+  $this->{API_KEY} = $ENV{'OPENEXCHANGE_API_KEY'};
 
-  $this->{API_KEY} = $args->{API_KEY};
+  $this->{API_KEY} =
+    $args->{API_KEY} if (ref $args eq 'HASH') and (exists $args->{API_KEY});
   $this->{refresh} = 0;
   $this->{refresh} = not $args->{cache} if exists $args->{cache};
 
+  # Return nothing if API_KEY not set
+  return unless ($this->{API_KEY});
+
+  ### API_KEY: $this->{API_KEY}
+
   return $this;
-}
+
+} # end new
 
 sub multipliers
 {
@@ -84,7 +91,7 @@ sub multipliers
   ### At least one code not found: $from, $to
 
   return;
-}
+} # end multipliers
 
 1;
 
@@ -97,8 +104,9 @@ https://openexchangerates.org
 
     use Finance::Quote;
     
-    $q = Finance::Quote->new(currency_rates => {order        => ['OpenExchange'],
-                                                openexchange => {API_KEY => ...}});
+    $q = Finance::Quote->new(currency_rates =>
+           {order => ['OpenExchange'], openexchange => {API_KEY => ...}}
+         );
 
     $value = $q->currency('18.99 EUR', 'USD');
 
@@ -111,11 +119,18 @@ value in the currency indicated by the second argument.
 This module caches the currency rates for the lifetime of the quoter object,
 unless 'cache => 0' is included in the 'openexchange' options hash.
 
+=head1 Currency Module Selection
+
+The Finance::Quote currency method to be used can also be selected by setting
+the environment variable FQ_CURRENCY.
+
+    export FQ_CURRENCY=OpenExchange
+
 =head1 API_KEY
 
-https://openexchangerates.org requires users to register and obtain an API key.  
+https://openexchangerates.org requires users to register and obtain an API key.  Their free plan allows 1000 queries per month.
 
-The API key must be set by providing a 'openexchange' hash inside the
+The API key can be set by setting the environment variable OPENEXCHANGE_API_KEY or by providing a 'openexchange' hash inside the
 'currency_rates' hash to Finance::Quote->new as in the above example.
 
 =head1 Terms & Conditions


### PR DESCRIPTION
Currency Rate modules Fixer.pm and OpenExchange.pm only allowed API_KEYs passed as arguments. This pull request allows the keys to be read from environment variables.
Fixer.pm - FIXER_API_KEY
OpenExchange.pm - OPENEXCHANGE_API_KEY

This PR resolves #426.