### PR TITLE
Added FinanceAPI Currency Rates Module

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* New CurrencyRates module, CurrencyRates/FinanceAPI - Issue #427
 	* Fixed Bourso.pm - Issue #417
 	* Allowed Currency Rates modules Fixer.pm and OpenExchange.pm to read their API keys from environment variables - Issue #426
 

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -349,6 +349,22 @@
     - AUD AUD
     - INR INR
 #
+- module: CurrencyRates/FinanceAPI.pm
+  state: working
+  Added: 2024-09-22
+  changed: ~
+  removed: ~
+  urls: https://yfapi.net/v8/finance/chart/
+  apikey: true
+  notes: |
+    Allows FINANCEAPI_API_KEY environment variable.
+    Running test file requires TEST_FINANCEAPI_API_KEY environment variable
+  testfile: currency.t
+  testcases:
+    - USD EUR
+    - GBP IDR
+    - IDR CAD
+#
 - module: CurrencyRates/Fixer.pm
   state: working
   Added: TBD

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -1,5 +1,7 @@
 #!/usr/bin/perl -w
 #
+#    vi: set ts=2 sw=2 noai ic showmode showmatch:  
+#
 #    Copyright (C) 1998, Dj Padzensky <djpadz@padz.net>
 #    Copyright (C) 1998, 1999 Linas Vepstas <linas@linas.org>
 #    Copyright (C) 2000, Yannick LE NY <y-le-ny@ifrance.com>
@@ -52,6 +54,7 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     AlphaVantage
     CurrencyFreaks
     ECB
+    FinanceAPI
     Fixer
     OpenExchange
     YahooJSON
@@ -1680,6 +1683,7 @@ http://www.gnucash.org/
   Finance::Quote::CurrencyRates::AlphaVantage,
   Finance::Quote::CurrencyRates::CurrencyFreaks,
   Finance::Quote::CurrencyRates::ECB,
+  Finance::Quote::CurrencyRates::FinanceAPI,
   Finance::Quote::CurrencyRates::Fixer,
   Finance::Quote::CurrencyRates::OpenExchange,
   Finance::Quote::CurrencyRates::YahooJSON,

--- a/lib/Finance/Quote/CurrencyRates/FinanceAPI.pm
+++ b/lib/Finance/Quote/CurrencyRates/FinanceAPI.pm
@@ -1,0 +1,156 @@
+#!/usr/bin/perl -w
+# vi: set ts=2 sw=2 ic noai showmode showmatch:  
+
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#    02110-1301, USA
+
+#    Copyright (C) 2024, Bruce Schuck <bschuck@asgard-systems.com>
+
+#    Changes:
+#    2024-09-22 - Initial version. Base code opied from
+#    CurrencyRates/YahooJSON.pm
+
+package Finance::Quote::CurrencyRates::FinanceAPI;
+
+use strict;
+use warnings;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use JSON;
+
+# VERSION
+
+my $YIND_URL_HEAD = 'https://yfapi.net/v8/finance/chart/';
+my $YIND_URL_TAIL = '?metrics=high&interval=1d&range=1d';
+
+sub new
+{
+  my $self = shift;
+  my $class = ref($self) || $self;
+
+  my $this = {};
+  bless $this, $class;
+
+  my $args = shift;
+
+  ### FinanceAPI->new args : $args
+
+  # FinanceAPI is permitted to use an environment variable for API key 
+  # (for backwards compatibility).
+  # New modules should use the API_KEY from args.
+
+  $this->{API_KEY} = $ENV{'FINANCEAPI_API_KEY'};
+  $this->{API_KEY} = $args->{API_KEY} if (ref $args eq 'HASH') and (exists $args->{API_KEY});
+
+  return $this;
+}
+
+sub multipliers
+{
+  my ($this, $ua, $from, $to) = @_;
+
+  my $json_data;
+  my $rate;
+
+# Set headers. API key is sent as a header.
+  my @ua_headers = (
+    'Accept' => 'application/json',
+    'X-API-KEY' => $this->{API_KEY},
+  );
+
+  my $reply = $ua->get($YIND_URL_HEAD
+      . ${from}
+      . ${to}
+      . '%3DX'
+      . $YIND_URL_TAIL, @ua_headers);
+
+  ### HTTP Status: $reply->code
+  return unless ($reply->code == 200);
+
+  my $body = $reply->content;
+
+  $json_data = JSON::decode_json $body;
+
+  ### JSON: $json_data
+
+  if ( !$json_data || !$json_data->{'chart'}->{'result'}->[0]->{'meta'}->{'regularMarketPrice'} ) {
+    return;
+  }
+
+  $rate =
+    $json_data->{'chart'}->{'result'}->[0]->{'meta'}->{'regularMarketPrice'};
+
+  ### Rate from JSON: $rate
+
+  return unless $rate + 0;
+
+  # For small rates, request the inverse 
+  if ($rate < 0.001) {
+    ### Rate is too small, requesting inverse : $rate
+    my ($a, $b) = $this->multipliers($ua, $to, $from);
+    return ($b, $a);
+  }
+
+  return (1.0, $rate);
+}
+
+
+1;
+
+=head1 NAME
+
+Finance::Quote::CurrencyRates::FinanceAPI - Obtain currency rates from
+https://yfapi.net/v8/finance/chart/.
+
+=head1 SYNOPSIS
+
+    use Finance::Quote;
+    
+    $q = Finance::Quote->new(currency_rates =>
+         {order => ['FinanceAPI'],
+          financeapi => {API_KEY => ...}
+         });
+
+    $value = $q->currency('18.99 EUR', 'USD');
+
+=head1 DESCRIPTION
+
+This module fetches currency rates from
+https://yfapi.net/v8/finance/chart/ provides data to Finance::Quote
+to convert the first argument to the equivalent value in the currency
+indicated by the second argument.
+
+This module is not the default currency conversion module for a Finance::Quote
+object. 
+
+=head1 API_KEY
+
+https://financeapi.net requires users to register and obtain an API key.  
+
+The API key can be set by setting the Environment variable
+"FINANCEAPI_API_KEY" or providing a 'financeapi' hash inside the
+'currency_rates' hash to Finance::Quote->new as in the above example.
+
+=head1 Terms & Conditions
+
+Use of https://yfapi.net/v8/finance/chart/ is
+governed by any terms & conditions of that site.
+
+Finance::Quote is released under the GNU General Public License, version 2,
+which explicitly carries a "No Warranty" clause.
+
+=cut

--- a/t/currency.t
+++ b/t/currency.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+# vi: set ts=2 sw=2 noai ic showmode showmatch:  
 
 use constant DEBUG => $ENV{DEBUG};
 use if DEBUG, Smart::Comments, '###';
@@ -47,7 +48,7 @@ sub module_check
   }
 }
 
-plan tests => 7;
+plan tests => 8;
 
 # Check that FQ fails on bogus CurrencyRates method
 my $q = Finance::Quote->new('currency_rates' => {order => ['DoesNotExist']});
@@ -100,6 +101,21 @@ subtest 'Fixer' => sub {
 
   module_check('Fixer', \@valid, \@invalid, {cache => 1, API_KEY => $ENV{TEST_FIXER_API_KEY}});
 };
+
+# Check FinanceAPI
+subtest 'FinanceAPI' => sub {
+  if ( not $ENV{TEST_FINANCEAPI_API_KEY} ) {
+    plan skip_all =>
+        'Set $ENV{TEST_FINANCEAPI_API_KEY} to run this test; get one at https://financeapi.net';
+  }
+
+  my @valid   =
+    ( ['100.00 USD', 'EUR'], ['1.00 GBP', 'IDR'], ['1.23 IDR', 'CAD'] );
+  my @invalid = ( ['20.12 ZZZ', 'GBP'] );
+
+  module_check('FinanceAPI', \@valid, \@invalid, {cache => 1, API_KEY => $ENV{TEST_FINANCEAPI_API_KEY}});
+};
+
 
 # Check YahooJSON
 subtest 'YahooJSON' => sub {


### PR DESCRIPTION
New Currency Rates module.
Requires API KEY from https://financeapi.net.
Key can be passed in via argument or FINANCEAPI_API_KEY environment variable.

Merging this PR will close #427.