### PR TITLE
Updated YahooJSON to validate dividend yield.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Modified YahooJSON to deal with "nan" as dividend yield in JSON.
 	* New CurrencyRates module, CurrencyRates/FinanceAPI - Issue #427
 	* Fixed Bourso.pm - Issue #417
 	* Allowed Currency Rates modules Fixer.pm and OpenExchange.pm to read their API keys from environment variables - Issue #426

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1282,13 +1282,13 @@
 - module: YahooJSON.pm
   state: working
   added:
-  changed: 2024-05-01
+  changed: 2024-09-23
   removed:
   urls:
     - https://query2.finance.yahoo.com/v11/finance/quoteSummary/?symbol=...&modules=price,summaryDetail,defaultKeyStatistics
   apikey: false
   notes: |
-    Module to get data from Yahoo's API
+    Module to get data from Yahoo's unpublished API
     See issue https://github.com/finance-quote/finance-quote/issues/264
     Dependability of Yahoo REST API has been spotty.
     Code needed to be added to use Cookies and a "crumb" from Yahoo.

--- a/lib/Finance/Quote/YahooJSON.pm
+++ b/lib/Finance/Quote/YahooJSON.pm
@@ -137,7 +137,7 @@ sub yahoo_json {
     if ($reply->code != 200) {
         foreach my $symbol (@stocks) {
             $info{$symbol, "success"} = 0;
-            $info{$symbol, "errormsg"} = "Error accessing queary.finance.yahoo.com/v1/test/getcrumb: $@";
+            $info{$symbol, "errormsg"} = "Error accessing query2.finance.yahoo.com/v1/test/getcrumb: $@";
         }     
         return wantarray() ? %info : \%info;
     }
@@ -258,7 +258,9 @@ sub yahoo_json {
                   # in Strawberry perl 5.18.2 in Windows
                   local $^W = 0;
                   $info{ $stocks, "div_yield" } =
-                    $json_resources_summaryDetail->{'trailingAnnualDividendYield'}{'raw'} * 100;
+                    $json_resources_summaryDetail->{'trailingAnnualDividendYield'}{'raw'} =~ m/[\d,\.]+/ ?
+                    $json_resources_summaryDetail->{'trailingAnnualDividendYield'}{'raw'} * 100          :
+                    0.0;
                 }
                 $info{ $stocks, "eps"} =
                     $json_resources_defaultKeyStatistics->{'trailingEps'}{'raw'};


### PR DESCRIPTION
JSON field `trailingAnnualDividendYield` for some securities contains "nan" instead of being null or 0.