### PR TITLE
Update MorninstarJP to use xml data from www.wealthadvisor.co.jp

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -805,9 +805,9 @@
 - module: MorningstarJP.pm
   state: working
   added: TBD
-  changed: 2023-04-08
+  changed: 2024-10-26
   removed: ~
-  urls: https://www.wealthadvisor.co.jp/FundData/DownloadStdYmd.do?fnc=
+  urls: https://www.wealthadvisor.co.jp/xml/
   apikey: false
   notes: ~
   testfile: morningstarJP.t

--- a/dist.ini
+++ b/dist.ini
@@ -76,6 +76,8 @@ Module::Load = 0.36
 Mozilla::CA = 0
 Test2 = 1.302167
 URI::Escape = 3.31
+XML::Parser = 0
+XML::Encoding = 0
 
 [Prereqs / TestRequires]
 Date::Range = 0

--- a/t/morningstarJP.t
+++ b/t/morningstarJP.t
@@ -8,7 +8,7 @@ if (not $ENV{ONLINE_TEST}) {
     plan skip_all => 'Set $ENV{ONLINE_TEST} to run this test';
 }
 
-plan tests => 9 * 2;
+plan tests => 10 * 2;
 
 # Find out today
 my $calcDay = DateTime->now();
@@ -24,11 +24,13 @@ my @funds = ( "2009100101", "2002013108" );
 my %info = $q->morningstarjp(@funds);
 ok(%info);
 
+### %info
 # Check that the symbol/name, date, currency and nav defined for all of the funds.
 foreach my $fund (@funds)
 {
+  ok( $info{ $fund, "success" }, 'success' );
 
-  # NAV date should be within 10 days of today, but we will allow +- 1 day
+  # Price date should be within 10 days of today, but we will allow +- 1 day
   # on top of that for running tests outside of Asia/Tokyo timezone
   my $fndyear  = substr( $info{ $fund, "isodate" }, 0, 4 );
   my $fndmonth = substr( $info{ $fund, "isodate" }, 5, 2 );
@@ -42,10 +44,10 @@ foreach my $fund (@funds)
 
   cmp_ok( $info{ $fund, 'currency' }, 'eq', 'JPY',           'currency' );
   cmp_ok( $info{ $fund, 'method' },   'eq', 'MorningstarJP', 'method' );
-  cmp_ok( $info{ $fund, 'name' },     'eq', $fund,           'name' );
+  cmp_ok( $info{ $fund, 'name' },     'ne', '',              'name' );
+  cmp_ok( $info{ $fund, "price" },    '>',  0,               'price' );
   cmp_ok( $info{ $fund, "nav" },      '>',  0,               'nav' );
-  ok( $info{ $fund, "success" }, 'success' );
-  cmp_ok( $info{ $fund, 'symbol' }, 'eq', $fund, 'symbol' );
+  cmp_ok( $info{ $fund, 'symbol' },   'eq', $fund,           'symbol' );
 }
 
 # Check that a bogus symbol returns no-success.


### PR DESCRIPTION
I took a liberty to rewrite the module. I wasn't sure how to interpet the data that is returned in the xml, please double check it. I decided to use the fund name in `name` field instead of its symbol. Please let me know if anything needs to be updated.

Please also see the note about Shift_JIS encoding. I am no expert in this matter and not really sure how to verify if I picked the right one. I guess a funds with names that contain a few conflicting character could be chosen (Yen sign?) and verify that it has been decoded correctly. See this https://github.com/steve-m-hay/XML-Encoding/blob/e48f2c7/maps/Japanese_Encodings.msg. Alternatively, the `XML::Encoding` module could be updated, or `Finance::Quote` could be shipped with it's own encmap file. Unfortunately, I can't read kanji, which makes these changes that more difficult.

This fixes #443