### PR TITLE
Return actual multipliers for CurrencyFreaks.pm module

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Updated CurrencyFreaks.pm to return actual multipliers for base currency rather then computed conversion rate
 	* Added methodinfo hash to Fool.pm
 	* Fixed MorningstarJP.pm - Issue #443 - PR #451
 

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -355,12 +355,12 @@
 - module: CurrencyRates/CurrencyFreaks.pm
   state: working
   Added: 2024-05-09
-  changed: ~
+  changed: 2025-01-09
   removed: ~
   urls: https://api.currencyfreaks.com/v2.0/rates/latest?apikey=YOUR_APIKEY&symbols={CURRENCYCODE},{CURRENCYCODE},...
   apikey: true
   notes: |
-    Newly module as of 5/9/2024
+    New module as of 5/9/2024
   testfile: currency.t
   testcases:
     - USD EUR

--- a/lib/Finance/Quote/CurrencyRates/CurrencyFreaks.pm
+++ b/lib/Finance/Quote/CurrencyRates/CurrencyFreaks.pm
@@ -91,7 +91,7 @@ sub multipliers
 
   my $json_data = decode_json ($body);
 
-  if ( !$json_data->{'rates'}->{$from} || !$json_data->{'rates'}->{$to} ) {
+  if ( !$json_data->{'rates'}->{${from}} || !$json_data->{'rates'}->{${to}} ) {
     return;
   }
 

--- a/lib/Finance/Quote/CurrencyRates/CurrencyFreaks.pm
+++ b/lib/Finance/Quote/CurrencyRates/CurrencyFreaks.pm
@@ -118,7 +118,8 @@ sub multipliers
     return ($b, $a);
   }
 
-  return (1.0, $rate);
+  # return actual multipliers that are relative to a third currency 
+  return ($json_data->{'rates'}->{${from}}, $json_data->{'rates'}->{${to}});
 }
 
 


### PR DESCRIPTION
Updated CurrencyFreaks.pm to return actual multipliers for base currency rather then computed conversion rate.