### PR TITLE
Adding Hong Kong stock support to GoogleWeb

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* GoogleWeb - Add support for Hong Kong Exchange - PR #476
 	* YahooJSON - Adjust other currency fields when data is returned in GBp, ZAc, or ILA.
 	* Added label wkn, ìsin, close, ask, bid, p_change, time to OnVista.pm
 	* Modified OnVista.pm to enable search by ISIN and WKN and search for ETFs

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -642,7 +642,7 @@
 - module: GoogleWeb.pm
   state: working
   added: 2023-09-16
-  changed: 2023-12-16
+  changed: 2025-03-06
   removed: ~
   urls: https://www.google.com/finance/
   apikey: false

--- a/lib/Finance/Quote/GoogleWeb.pm
+++ b/lib/Finance/Quote/GoogleWeb.pm
@@ -84,8 +84,8 @@ sub googleweb {
       $tree = HTML::TreeBuilder->new;
       if ($tree->parse_content($body)) {
         #
-        # Get link with exchange appended (MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS)
-        $taglink = $tree->look_down(_tag => 'a', href => qr!^./quote/$ucstock:(MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS)!);
+        # Get link with exchange appended (MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS|HKG)
+        $taglink = $tree->look_down(_tag => 'a', href => qr!^./quote/$ucstock:(MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS|HKG)!);
         if ($taglink) {
           $link = $taglink->attr('href');
           $link =~ s|\./quote|quote|;

--- a/lib/Finance/Quote/GoogleWeb.pm
+++ b/lib/Finance/Quote/GoogleWeb.pm
@@ -35,20 +35,28 @@ use if DEBUG, 'Smart::Comments', '###';
 
 my $GOOGLE_URL = 'https://www.google.com/finance/';
 
-sub methods {
-  return (googleweb => \&googleweb,
-          bats      => \&googleweb,
-          nyse      => \&googleweb,
-          nasdaq    => \&googleweb);
+our $DISPLAY    = 'GoogleWeb - Scrapes www.google.com/finance/';
+our @LABELS     = qw/symbol name last date currency method/;
+our $METHODHASH = {subroutine => \&googleweb,
+                   display    => $DISPLAY, 
+                   labels     => \@LABELS};
+
+sub methodinfo {
+    return ( 
+        googleweb => $METHODHASH,
+        bats      => $METHODHASH,
+        nyse      => $METHODHASH,
+        nasdaq    => $METHODHASH,
+    );
 }
 
-our @labels = qw/symbol name last date currency method/;
+sub labels {
+  my %m = methodinfo();
+  return map {$_ => [@{$m{$_}{labels}}] } keys %m;
+}
 
-sub labels { 
-  return (googleweb => \@labels,
-          bats      => \@labels,
-          nyse      => \@labels,
-          nasdaq    => \@labels); 
+sub methods {
+  my %m = methodinfo(); return map {$_ => $m{$_}{subroutine} } keys %m;
 }
 
 sub googleweb {


### PR DESCRIPTION
With the recent and repeated problems with YahooJson, I think the GoogleWeb option is becoming more and more viable and valuable. Here's a very small tweak for it to handle stock traded in the Hong Kong Stock Exchange (HKEX), with ticket symbols such as "2828", "0700", etc.

The logic today is to fetch from a Google Finance web URL for a ticker such as "TSLA", and then find an "A" anchor in the format of something like "TSLA:NASDAQ" and then fetch that page. There is a limited set of "exchanges" that are supported there, and I just added "HKG". I'm sure there are others (like Toronto TSX, London LON, etc.), if the reviewer(s) are willing, please feel free to add those too.

Thank you for the good work!