### PR TITLE
Comdirect: add etf, more labels and EXCHANGE feature

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Added ETFs search, more labels and EXCHANGE feature to Comdirect.pm - PR #478
 	* YahooJSON - Adjust other currency fields when data is returned in GBp, ZAc, or ILA.
 	* Added label wkn, ìsin, close, ask, bid, p_change, time to OnVista.pm
 	* Modified OnVista.pm to enable search by ISIN and WKN and search for ETFs

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -238,7 +238,7 @@
 - module: Comdirect.pm
   state: working
   added: TBD
-  changed: 2024-10-18
+  changed: 2025-03-13
   removed: ~
   urls: https://www.comdirect.de/inf/search/all.html?SEARCH_VALUE=
   apikey: false
@@ -248,6 +248,7 @@
     - VWAGY
     - Volkswagen
     - DE0007664039
+    - FR0010510800
 #
 - module: CSE.pm
   state: working

--- a/lib/Finance/Quote/Comdirect.pm
+++ b/lib/Finance/Quote/Comdirect.pm
@@ -76,7 +76,7 @@ RETRY:
       ### [<now>] Body: $body
 
       my $tree = HTML::TreeBuilder->new;
-      unless ($tree->parse(encode_utf8($body))) {
+      unless ($tree->parse($body)) {
         $info{ $symbol, "success" } = 0;
         $info{ $symbol, "errormsg" } = 'Parse body failed';
         next;
@@ -92,7 +92,7 @@ RETRY:
         next;
       }
 
-      my %exchange2nid = map { $_->as_text => $_->attr('value') }
+      my %exchange2nid = map { encode_utf8($_->as_text) => $_->attr('value') }
         grep { ref eq 'HTML::Element' and $_->tag eq 'option' } $select->content_list;
 
       my $option = $select->look_down(_tag => 'option', selected => 'selected');
@@ -102,7 +102,7 @@ RETRY:
         next;
       }
 
-      if ($exchange and $exchange ne $option->as_text) {
+      if ($exchange and $exchange ne encode_utf8($option->as_text)) {
         unless (exists($exchange2nid{$exchange}) and $try < 2) {
             $info{ $symbol, "success" } = 0;
             $info{ $symbol, "errormsg" } = 'Marketplace not found: ' . "'".$exchange."'";
@@ -117,12 +117,12 @@ RETRY:
       }
 
       $info{$symbol, 'exchanges'} = [ sort keys %exchange2nid ];
-      $info{$symbol, 'exchange'} = $option->as_text;
+      $info{$symbol, 'exchange'} = encode_utf8($option->as_text);
       $info{$symbol, 'notation_id'} = $option->attr('value');
 
       my $h1 = $tree->look_down(_tag => 'h1');
       if ($h1) {
-        $info{$symbol, 'name'} = trim($h1->as_text);
+        $info{$symbol, 'name'} = trim(encode_utf8($h1->as_text));
       }
 
       my $div = $tree->look_down(_tag => 'div', class => "realtime-indicator");

--- a/lib/Finance/Quote/Comdirect.pm
+++ b/lib/Finance/Quote/Comdirect.pm
@@ -26,6 +26,7 @@ use HTML::TableExtract;
 use HTML::TreeBuilder;
 use LWP::UserAgent;
 use String::Util qw(trim);
+use Encode qw(encode_utf8);
 
 # VERSION
 
@@ -75,7 +76,7 @@ RETRY:
       ### [<now>] Body: $body
 
       my $tree = HTML::TreeBuilder->new;
-      unless ($tree->parse($body)) {
+      unless ($tree->parse(encode_utf8($body))) {
         $info{ $symbol, "success" } = 0;
         $info{ $symbol, "errormsg" } = 'Parse body failed';
         next;

--- a/lib/Finance/Quote/Comdirect.pm
+++ b/lib/Finance/Quote/Comdirect.pm
@@ -195,7 +195,8 @@ Finance::Quote->new().
 =head1 LABELS RETURNED
 
 The following labels may be returned by Finance::Quote::Comdirect:
-isodate, last, currency, open, high, low, name, isin, method, success
+isodate, time, last, currency, open, high, low, name, isin, wkn,
+p_change, ask, bid, method, exchange, success
 
 =head1 TERMS & CONDITIONS
 

--- a/lib/Finance/Quote/Comdirect.pm
+++ b/lib/Finance/Quote/Comdirect.pm
@@ -30,7 +30,8 @@ use String::Util qw(trim);
 # VERSION
 
 our $DISPLAY    = 'Comdirect - Frankfurt and other exchanges';
-our @LABELS     = qw/symbol name open high low last date time p_change ask bid currency isin wkn method exchange/;
+our $FEATURES   = { 'EXCHANGE' => 'select market place (i.e. "gettex", "Xetra", "Tradegate")' };
+our @LABELS     = qw/symbol name open high low last date time p_change ask bid currency isin wkn method exchange exchanges/;
 our $METHODHASH = {subroutine => \&comdirect,
                    display => $DISPLAY, 
                    labels => \@LABELS};
@@ -57,7 +58,11 @@ sub comdirect {
   my (%info, %pricetable, %infotable);
 
   foreach my $symbol (@_) {
-      my $url   = 'https://www.comdirect.de/inf/search/all.html?SEARCH_VALUE=' . $symbol;
+      my $try = 0;
+      my $url = 'https://www.comdirect.de/inf/search/all.html?SEARCH_VALUE=' . $symbol;
+
+RETRY:
+      ++$try;
       my $reply = $ua->get($url);
 
       unless ($reply->is_success) {
@@ -76,6 +81,44 @@ sub comdirect {
         next;
       }
 
+      my $exchange = exists $quoter->{module_specific_data}->{comdirect}->{EXCHANGE} ?
+                            $quoter->{module_specific_data}->{comdirect}->{EXCHANGE} : undef;
+
+      my $select = $tree->look_down(_tag => 'select', name=> 'ID_NOTATION', id=> "marketSelect");
+      unless($select) {
+        $info{ $symbol, "success" } = 0;
+        $info{ $symbol, "errormsg" } = 'Parse marketplaces failed.';
+        next;
+      }
+
+      my %exchange2nid = map { $_->as_text => $_->attr('value') }
+        grep { ref eq 'HTML::Element' and $_->tag eq 'option' } $select->content_list;
+
+      my $option = $select->look_down(_tag => 'option', selected => 'selected');
+      unless($option) {
+        $info{ $symbol, "success" } = 0;
+        $info{ $symbol, "errormsg" } = 'Parse selected marketplace failed.';
+        next;
+      }
+
+      if ($exchange and $exchange ne $option->as_text) {
+        unless (exists($exchange2nid{$exchange}) and $try < 2) {
+            $info{ $symbol, "success" } = 0;
+            $info{ $symbol, "errormsg" } = 'Marketplace not found: ' . "'".$exchange."'";
+            next;
+        }
+
+        my $u = $reply->request->url;
+        $u->query_param("ID_NOTATION" => $exchange2nid{$exchange});
+        $url = $u->as_string;
+
+        goto RETRY;
+      }
+
+      $info{$symbol, 'exchanges'} = [ sort keys %exchange2nid ];
+      $info{$symbol, 'exchange'} = $option->as_text;
+      $info{$symbol, 'notation_id'} = $option->attr('value');
+
       my $h1 = $tree->look_down(_tag => 'h1');
       if ($h1) {
         $info{$symbol, 'name'} = trim($h1->as_text);
@@ -87,15 +130,6 @@ sub comdirect {
         if (scalar(@span) >= 2) {
           $info{$symbol, 'last'}     = $1 if trim($span[-2]->as_text) =~ /^([0-9.]+)/;
           $info{$symbol, 'currency'} = $1 if trim($span[-1]->as_text) =~ /^([A-Z]+)/;
-        }
-      }
-
-      my $select = $tree->look_down(_tag => 'select', name=> 'ID_NOTATION', id=> "marketSelect");
-      if ($select) {
-        my $option = $select->look_down(_tag => 'option', selected => 'selected');
-        if ($option) {
-          $info{$symbol, 'exchange'} = $option->as_text;
-          $info{$symbol, 'notation_id'} = $option->attr('value');
         }
       }
 
@@ -125,30 +159,29 @@ sub comdirect {
       foreach my $row ($te->rows) {
         ### [<now>] Row: $row
         if ($row->[0] eq 'Zeit' && $pricetable{'Zeit'}) {next}
-        $pricetable{$row->[0]} = $row->[1];
+        $pricetable{$row->[0]} = trim($row->[1]);
       }
       ### [<now>] Pricetable hash: %pricetable
 
-      unless (exists $pricetable{Zeit} and exists $pricetable{Aktuell}) {
+      unless (exists $pricetable{Zeit}) {
         $info{ $symbol, "success" } = 0;
         $info{ $symbol, "errormsg" } = 'Parse failed.';
         next; 
       }
 
-      foreach (qw(Aktuell Hoch Tief Geld Brief), "Er\x{f6}ffnung", "Schluss Vortag", "Diff. Vortag") {
-        if (defined $pricetable{$_}) {
-          $pricetable{$_} =~ s/^\s+|\s+$//g;
-          $pricetable{$_} =~ s/^Realtime Kurs//;
-          $pricetable{$_} =~ s/,/./;
-        }
-      }
+      my %mapping = ( 'high' => 'Hoch',
+                      'low' => 'Tief',
+                      'bid' => 'Geld',
+                      'ask' => 'Brief',
+                      'open' => "Er\x{f6}ffnung",
+                      'close' => "Schluss Vortag" );
 
-      $info{$symbol, 'open'}      = $pricetable{"Er\x{f6}ffnung"};
-      $info{$symbol, 'close'}     = $pricetable{"Schluss Vortag"};
-      $info{$symbol, 'high'}      = $pricetable{Hoch};
-      $info{$symbol, 'low'}       = $pricetable{Tief};
-      $info{$symbol, 'ask'}       = $pricetable{Brief};
-      $info{$symbol, 'bid'}       = $pricetable{Geld};
+      while ((my $fqkey, my $cbkey) = each (%mapping)) {
+        $info{$symbol, $fqkey} = $1.'.'.$2
+          if (exists($pricetable{$cbkey})
+            and defined($pricetable{$cbkey})
+            and $pricetable{$cbkey} =~ /^(\d+),(\d+)/);
+      }
 
       $info{$symbol, 'p_change'}  = $1 if $pricetable{"Diff. Vortag"} =~ /([+-][0-9]+\.[0-9]+)\x{a0}%/;
 
@@ -163,6 +196,7 @@ sub comdirect {
 
       $info{$symbol, 'method'}    = 'comdirect';
       $info{$symbol, 'success'}   = 1;
+
   }
 
   return wantarray() ? %info : \%info;
@@ -179,10 +213,14 @@ Finance::Quote::Comdirect - Obtain quotes from https://www.comdirect.de
     use Finance::Quote;
 
     $q = Finance::Quote->new;
+    or
+    $q = Finance::Quote->new("Comdirect", "comdirect" => { "EXCHANGE" => "Xetra" });
 
     %info = Finance::Quote->fetch('comdirect', 'DE0007664039');
     %info = Finance::Quote->fetch('comdirect', 'Volkswagen');
     %info = Finance::Quote->fetch('comdirect', 'VWAGY');
+
+    @exchanges = @{ $info{ "VWAGY", "exchanges" } }; # List of available marketplaces
 
 =head1 DESCRIPTION
 
@@ -192,11 +230,24 @@ This module is loaded by default on a Finance::Quote object. It's also possible
 to load it explicitly by placing 'Comdirect' in the argument list to
 Finance::Quote->new().
 
+=head1 EXCHANGE
+
+https://www.comdirect.de/ supports different marketplaces:
+
+  "gettex"
+  "Xetra"
+  "Frankfurt"
+  "Tradegate"
+  ... any many more ...
+
+The EXCHANGE may be set by providing a module specific hash to
+Finance::Quote->new as in the above example (optional).
+
 =head1 LABELS RETURNED
 
 The following labels may be returned by Finance::Quote::Comdirect:
 isodate, time, last, currency, open, high, low, name, isin, wkn,
-p_change, ask, bid, method, exchange, success
+p_change, ask, bid, method, exchange, success, exchanges
 
 =head1 TERMS & CONDITIONS
 

--- a/t/comdirect.t
+++ b/t/comdirect.t
@@ -19,7 +19,8 @@ if (not $ENV{ONLINE_TEST}) {
 
 my %valid    = ('VWAGY'        => 'Volkswagen',
                 'Volkswagen'   => 'Volkswagen',
-                'DE0007664039' => 'Volkswagen'
+                'DE0007664039' => 'Volkswagen',
+                'FR0010510800' => 'Amundi EUR Overnight Return UCITS ETF'
                );
 
 my @invalid  = ('BOGUS');


### PR DESCRIPTION
improves the Comdirect module:
- fix ETF search support
- add label `time`, `p_change`, `ask`, `bid`, `wkn`, `exchange` 
- a new label `exchanges` contains the list of available marketplaces
- the marketplace can be selected using the 'EXCHANGE' feature. This feature is already under development for other modules.

Update 2025-03-16:
- fix encoding
  - i.e.: CH0038863350 name: Nestl**é** 



