### PR TITLE
Added 'symbol not found' message to AlphaVantage.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* AlphaVantage - return 'symbol not found' when no price data is returned.
 	* ASX - Changed error message when symbol isn't found - Issue #497
 	* Added a new module to fetch the fund nav from CMBChina - PR #494
 	* Added Cookie Jar to Comdirect user agent - Issue #491

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -96,7 +96,7 @@
 - module: AlphaVantage.pm
   state: working
   added:
-  changed: 2024-11-05
+  changed: 2025-06-15
   removed:
   urls:
     - https://www.alphavantage.co/query?function=GLOBAL_QUOTE&apikey=$ALPHAVANTAGE_API_KEY&symbol=

--- a/lib/Finance/Quote/AlphaVantage.pm
+++ b/lib/Finance/Quote/AlphaVantage.pm
@@ -271,6 +271,14 @@ sub alphavantage {
             next;
         }
 
+        # AlphaVantage can return an empty "Global Quote" when
+        # a symbol is not found.
+        if ( ! $quote->{'01. symbol'} ) {
+            $info{ $stock, 'success' } = 0;
+            $info{ $stock, 'errormsg' } = "Symbol $stock not found.";
+            next;
+        }
+
         # %ts holds data as
         #  {
         #     "Global Quote": {


### PR DESCRIPTION
I recently discovered that when a symbol is not found from AlphaVantage, the JSON returned is
```
{
    "Global Quote": {}
}
```

The modules sets success to "1" even though no price data is included in the returned hash.

This change checks that the "Global Quote" JSON structure contains the `"01. symbol": ...` field, otherwise it sets success to "0", and errormsg to "symbol ... not found."