### PR TITLE
Using official Tesouro Direto URL (www.tesourodireto.com.br)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Optimizing TesouroDireto.pm - Using official Tesouro Direto URL (https://www.tesourodireto.com.br/...)
 
 1.66      2025-07-05 11:34:42-07:00 America/Los_Angeles
 	* Modified CurrencyRates/CurrencyFreaks.pm to return from and to values instead of calculated rate.

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1191,11 +1191,10 @@
 - module: TesouroDireto.pm
   state: working
   added: 2022-02-06
-  changed: 2024-09-11
+  changed: 2025-07-07
   removed: ~
   urls:
-    - https://www.tesourodireto.com.br/titulos/precos-e-taxas.htm
-    - https://github.com/ghostnetrn/bot-tesouro-direto
+    - https://www.tesourodireto.com.br/json/br/com/b3/tesourodireto/service/api/treasurybondsinfo.json
   apikey: false
   notes: ~
   testfile: tesouro_direto.t

--- a/lib/Finance/Quote/TesouroDireto.pm
+++ b/lib/Finance/Quote/TesouroDireto.pm
@@ -33,8 +33,27 @@ use JSON;
 
 # VERSION
 
-sub methods { return (tesouro_direto => \&tesouro); }
-sub labels { return (tesouro_direto => [qw/exchange date isodate symbol name price last method currency/]); }
+our $DISPLAY    = 'Brazilian Govt Bonds, tesouro_direto';
+our $FEATURES   = {};
+our @LABELS     = qw/exchange date isodate symbol name price last method currency/;
+our $METHODHASH = {subroutine => \&tesouro,
+                   display => $DISPLAY,
+                   labels => \@LABELS,
+                   features => $FEATURES};
+
+sub methodinfo {
+    return (
+        tesouro_direto => $METHODHASH,
+    );
+}
+
+sub methods {
+    my %m = methodinfo(); return map {$_ => $m{$_}{subroutine} } keys %m;
+}
+
+sub labels {
+    my %m = methodinfo(); return map {$_ => [@{$m{$_}{labels}}] } keys %m;
+}
 
 sub tesouro
 {

--- a/lib/Finance/Quote/TesouroDireto.pm
+++ b/lib/Finance/Quote/TesouroDireto.pm
@@ -52,7 +52,10 @@ sub tesouro
       $fundhash{$fund} = 0;
   }
 
-  my $url = "https://raw.githubusercontent.com/ghostnetrn/bot-tesouro-direto/main/tesouro.json";
+  my $url = "https://www.tesourodireto.com.br/json/br/com/b3/tesourodireto/service/api/treasurybondsinfo.json";
+  $ua->agent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36');
+  $ua->timeout(10);
+  $ua->max_redirect(5);
   my $response = $ua->request(GET $url);
 
   if ($response->is_success) {

--- a/lib/Finance/Quote/TesouroDireto.pm
+++ b/lib/Finance/Quote/TesouroDireto.pm
@@ -125,7 +125,7 @@ Finance::Quote::TesouroDireto - Obtain quotes for Brazilian government bounds
 =head1 DESCRIPTION
 
 This module obtains quotes for Brazilian government bounds, obtained from
-https://www.tesourodireto.com.br/titulos/precos-e-taxas.htm
+https://www.tesourodireto.com.br/json/br/com/b3/tesourodireto/service/api/treasurybondsinfo.json
 
 =head1 LABELS RETURNED
 


### PR DESCRIPTION
Using official Tesouro Direto URL (www.tesourodireto.com.br) instead of taking the JSON from raw.githubusercontent.com that, being a copy, may be outdated