### PR TITLE
Correct syntax errors in SwissFundData.pm

### DIFF
--- a/lib/Finance/Quote/SwissFundData.pm
+++ b/lib/Finance/Quote/SwissFundData.pm
@@ -51,7 +51,7 @@ $SFDCH_LOOK_UP	= "https://www.swissfunddata.ch/sfdpub/en/funds/prices?text=";
 
 our $DISPLAY = "SwissFundData";
 our @LABELS = qw/name currency date nav isodate method success errormsg/;
-out $METHODHASH = {
+our $METHODHASH = {
 	subroutine => \&swissfunddata,
 	display => $DISPLAY,
 	labels => \@LABELS
@@ -159,7 +159,7 @@ sub swissfunddata  {
 	$info {$symbol, "isin"} = $isin;
 	$info {$symbol, "nav"} = $nav;
 	$info {$symbol, "currency"} = $currency;
-	$quoter->store_date(\%info, $symbol, {eurodate => $date);
+	$quoter->store_date(\%info, $symbol, {eurodate => $date});
 	$info {$symbol, "method"} = "swissfunddata";
 	# It seems that GnuCash insists on having the time set?!
 	$info {$symbol, "time"} = "12:00";


### PR DESCRIPTION
Corrected minor syntax errors in original PR #515.
Line 54: `out $METHODHASH` to `our $METHODHASH`
Line 162: `{eurodate => $date)` to `{eurodate => $date}`