### PR TITLE
XETRA.pm: trim whitespace from date-time before extracting the actual date value.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* XETRA.pm: trim whitespace from date-time before extracting the actual date value. PR #557
 	* Modified Stooq.pm to send cookies. Stooq requires European visitors to their website to accept cookies. Cookies are set using JavaScript. Current version of module hard codes these cookies gleaned from a browser session.
 	* Added CurrencyRates/TwelveData.pm.
 

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1400,7 +1400,7 @@
 - module: XETRA.pm
   state: working
   added: 2020-09-29
-  changed: 2025-01-25
+  changed: 2026-03-04
   removed: ~
   urls:
     - https://web.s-investor.de/app/aktien.htm?INST_ID=0000057

--- a/lib/Finance/Quote/XETRA.pm
+++ b/lib/Finance/Quote/XETRA.pm
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-#    vi: set ts=2 sw=2 noai ic showmode showmatch:  
+#    vi: set ts=2 sw=2 noai ic showmode showmatch:
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
@@ -20,6 +20,7 @@ package Finance::Quote::XETRA;
 use strict;
 use warnings;
 use HTML::Entities;
+use String::Util qw(trim);
 
 use constant DEBUG => $ENV{DEBUG};
 use if DEBUG, 'Smart::Comments';
@@ -35,12 +36,12 @@ our $DISPLAY    = 'XETRA - German Sparkasse banking group';
 our $FEATURES   = {'INST_ID' => 'Required Institution ID'};
 our @LABELS     = qw/symbol last close exchange volume open price change p_change/;
 our $METHODHASH = {subroutine => \&xetra,
-                   display => $DISPLAY, 
+                   display => $DISPLAY,
                    labels => \@LABELS,
                    features => $FEATURES};
 
 sub methodinfo {
-    return ( 
+    return (
         xetra   => $METHODHASH,
         europe  => $METHODHASH,
     );
@@ -102,7 +103,7 @@ sub xetra {
 
         $td1 = ($lastvalue->look_down('_tag'=>'td'))[7];
         @child = $td1->content_list;
-        my $date = substr($child[0], 0, 8);
+        my $date = substr(trim($child[0]), 0, 8);
 
         $td1 = ($lastvalue->look_down('_tag'=>'td'))[9];
         @child = $td1->content_list;


### PR DESCRIPTION
Should fix issue #556.