### PR TITLE
Add CurrencyRates/UniRate.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* Added CurrencyRates/UniRate.pm.
 
 1.69      2026-04-18 11:47:37-07:00 America/Los_Angeles
 	* Sinvestor.pm - trim whitespace before parsing date and price

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -476,6 +476,23 @@
     - GBP IDR
     - IDR CAD
 #
+- module: CurrencyRates/UniRate.pm
+  state: working
+  Added: 2026-04-26
+  changed: ~
+  removed: ~
+  urls: https://api.unirateapi.com/api/rates?from={CURRENCYCODE}&to={CURRENCYCODE}&api_key=YOUR_APIKEY
+  apikey: true
+  notes: |
+    Free tier covers /api/rates (1000+ currencies, fiat + crypto).
+    Running test file requires TEST_UNIRATE_API_KEY environment variable.
+  testfile: currency.t
+  testcases:
+    - USD EUR
+    - GBP IDR
+    - IDR CAD
+    - AUD AUD
+#
 - module: CurrencyRates/YahooJSON.pm
   state: working
   Added: 2023-04-09

--- a/lib/Finance/Quote.pm
+++ b/lib/Finance/Quote.pm
@@ -58,6 +58,7 @@ use vars qw/@ISA @EXPORT @EXPORT_OK @EXPORT_TAGS
     Fixer
     OpenExchange
     TwelveData
+    UniRate
     YahooJSON
 /;
 
@@ -1706,6 +1707,7 @@ http://www.gnucash.org/
   Finance::Quote::CurrencyRates::Fixer,
   Finance::Quote::CurrencyRates::OpenExchange,
   Finance::Quote::CurrencyRates::TwelveData,
+  Finance::Quote::CurrencyRates::UniRate,
   Finance::Quote::CurrencyRates::YahooJSON,
   Finance::Quote::AEX,
   Finance::Quote::ASEGR,

--- a/lib/Finance/Quote/CurrencyRates/UniRate.pm
+++ b/lib/Finance/Quote/CurrencyRates/UniRate.pm
@@ -44,6 +44,10 @@ sub new
 
   ### UniRate->new args : $args
 
+  # UniRate supports an environment variable for the API key for parity
+  # with the Twelvedata and FinanceAPI currency-rate modules. An explicit
+  # API_KEY in $args overrides the environment variable.
+  $this->{API_KEY} = $ENV{'UNIRATEAPI_API_KEY'};
   $this->{API_KEY} = $args->{API_KEY} if (ref $args eq 'HASH') and (exists $args->{API_KEY});
 
   return $this;
@@ -125,8 +129,10 @@ object.
 https://unirateapi.com requires users to register and obtain an API key.
 The free tier covers the current-rate lookups used by this module.
 
-The API key is set by providing a unirate hash inside the currency_rates hash
-to Finance::Quote->new as in the synopsis above.
+The API key can be set by setting the environment variable
+"UNIRATEAPI_API_KEY" or by providing a 'unirate' hash inside the
+'currency_rates' hash to Finance::Quote->new as in the synopsis above.
+An explicit value in the hash overrides the environment variable.
 
 =head1 Terms & Conditions
 

--- a/lib/Finance/Quote/CurrencyRates/UniRate.pm
+++ b/lib/Finance/Quote/CurrencyRates/UniRate.pm
@@ -1,0 +1,139 @@
+#!/usr/bin/perl -w
+# vi: set ts=2 sw=2 noai ic showmode showmatch:
+
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#    02110-1301, USA
+
+package Finance::Quote::CurrencyRates::UniRate;
+
+use strict;
+use warnings;
+
+use constant DEBUG => $ENV{DEBUG};
+use if DEBUG, 'Smart::Comments';
+
+use JSON;
+
+# VERSION
+
+sub parameters {
+  return ('API_KEY');
+}
+
+sub new
+{
+  my $self = shift;
+  my $class = ref($self) || $self;
+
+  my $this = {};
+  bless $this, $class;
+
+  my $args = shift;
+
+  ### UniRate->new args : $args
+
+  $this->{API_KEY} = $args->{API_KEY} if (ref $args eq 'HASH') and (exists $args->{API_KEY});
+
+  return $this;
+}
+
+sub multipliers
+{
+  my ($this, $ua, $from, $to) = @_;
+
+  my $url = 'https://api.unirateapi.com/api/rates'
+      . '?from=' . ${from}
+      . '&to=' . ${to}
+      . '&api_key=' . $this->{API_KEY};
+
+  my $reply = $ua->get($url,
+      'Accept'     => 'application/json',
+      'User-Agent' => 'finance-quote-unirate/0.01');
+
+  return unless ($reply->code == 200);
+
+  my $body = $reply->content;
+
+  ### HTTP body: $body
+
+  my $json_data = eval { JSON::decode_json $body };
+  return if $@ or !$json_data;
+
+  return unless exists $json_data->{'rate'};
+
+  my $rate = $json_data->{'rate'};
+
+  ### Rate from JSON: $rate
+
+  return unless $rate + 0;
+
+  # For small rates, request the inverse.
+  if ($rate < 0.001) {
+    ### Rate is too small, requesting inverse : $rate
+    my ($a, $b) = $this->multipliers($ua, $to, $from);
+    return ($b, $a);
+  }
+
+  return (1.0, $rate);
+}
+
+
+1;
+
+__END__
+
+=head1 NAME
+
+Finance::Quote::CurrencyRates::UniRate - Obtain currency rates from
+https://unirateapi.com
+
+=head1 SYNOPSIS
+
+    use Finance::Quote;
+
+    $q = Finance::Quote->new(currency_rates => {order    => ['UniRate'],
+                                                unirate  => {API_KEY => ...}});
+
+    $value = $q->currency('18.99 EUR', 'USD');
+
+=head1 DESCRIPTION
+
+This module fetches currency rates from https://unirateapi.com and provides
+data to Finance::Quote to convert the first argument to the equivalent value
+in the currency indicated by the second argument.
+
+UniRate covers 1000+ currencies (fiat and crypto) with daily updates and a
+generous free tier. This module only uses the free /api/rates endpoint.
+
+This module is not the default currency conversion module for a Finance::Quote
+object.
+
+=head1 API_KEY
+
+https://unirateapi.com requires users to register and obtain an API key.
+The free tier covers the current-rate lookups used by this module.
+
+The API key is set by providing a unirate hash inside the currency_rates hash
+to Finance::Quote->new as in the synopsis above.
+
+=head1 Terms & Conditions
+
+Use of https://unirateapi.com is governed by any terms & conditions of that
+site.
+
+Finance::Quote is released under the GNU General Public License, version 2,
+which explicitly carries a "No Warranty" clause.
+
+=cut

--- a/t/currency.t
+++ b/t/currency.t
@@ -48,7 +48,7 @@ sub module_check
   }
 }
 
-plan tests => 8;
+plan tests => 9;
 
 # Check that FQ fails on bogus CurrencyRates method
 my $q = Finance::Quote->new('currency_rates' => {order => ['DoesNotExist']});
@@ -114,6 +114,19 @@ subtest 'FinanceAPI' => sub {
   my @invalid = ( ['20.12 ZZZ', 'GBP'] );
 
   module_check('FinanceAPI', \@valid, \@invalid, {cache => 1, API_KEY => $ENV{TEST_FINANCEAPI_API_KEY}});
+};
+
+# Check UniRate
+subtest 'UniRate' => sub {
+  if ( not $ENV{TEST_UNIRATE_API_KEY} ) {
+    plan skip_all =>
+        'Set $ENV{TEST_UNIRATE_API_KEY} to run this test; get one at https://unirateapi.com';
+  }
+
+  my @valid   = (['100.00 USD', 'EUR'], ['1.00 GBP', 'IDR'], ['1.23 IDR', 'CAD'], ['10.00 AUD', 'AUD']);
+  my @invalid = (['20.12 ZZZ', 'GBP']);
+
+  module_check('UniRate', \@valid, \@invalid, {API_KEY => $ENV{TEST_UNIRATE_API_KEY}});
 };
 
 # Check TwelveData


### PR DESCRIPTION
## Summary

Adds `Finance::Quote::CurrencyRates::UniRate` — a new pluggable currency-rate source backed by [UniRate](https://unirateapi.com). UniRate covers 1000+ currencies (fiat and crypto) with daily updates and a generous free tier.

```perl
$q = Finance::Quote->new(currency_rates => {order   => ['UniRate'],
                                            unirate => {API_KEY => ...}});

$value = $q->currency('18.99 EUR', 'USD');
```

## Why another currency source?

- **Broad crypto + fiat coverage** — covers symbols some existing sources don't (1000+ codes).
- **Free tier is enough for current rates** — this module only uses `/api/rates`, which is on the free plan; no pay-gate behaviour to surprise downstream users.
- **Pluggable failover slot** — slots cleanly into the existing `order =>` chain alongside ECB / Fixer / OpenExchange / etc., so users can layer it as primary or fallback.

## What's in this PR

- `lib/Finance/Quote/CurrencyRates/UniRate.pm` — new module (~90 LOC, mirrors the `CurrencyFreaks` / `AlphaVantage` pattern: `parameters()`, `new()`, `multipliers()`, with the small-rate inverse-flip).
- Wires `UniRate` into `@CURRENCY_RATES_MODULES` and `SEE ALSO` in `lib/Finance/Quote.pm`.
- New `Modules-README.yml` entry (state: working, apikey: true, testfile: `currency.t`, four test cases).
- `Changes` entry under `{{$NEXT}}`.
- `t/currency.t` subtest gated on `TEST_UNIRATE_API_KEY`, mirroring the layout used for the other API-key-backed sources.

## How it was tested

`prove -Ilib t/currency.t` with `ONLINE_TEST=1 TEST_UNIRATE_API_KEY=...`:

```
# Subtest: UniRate
    1..10
    ok 1
    ok 2 - 100.00 USD -> EUR = 85.4883990932263
    ok 4 - 1.00 GBP -> IDR = 23286.8656060185
    ok 6 - 1.23 IDR -> CAD = 9.75069016599033e-05
    ok 8 - 10.00 AUD -> AUD = 10.00
    ok 9 - identity check
    ok 10 - 20.12 ZZZ -> GBP failed as expected
ok 7 - UniRate
```

Cross-checked live rates against the YahooJSON subtest in the same run — values agree to within ~0.2% (independent sources, expected drift).

POD also passes the author test: `TEST_AUTHOR=1 prove -Ilib t/01-pod.t` → `Files=1, Tests=56, Result: PASS`.

## Implementation notes

- Single `GET /api/rates?from=…&to=…&api_key=…` per call. Response is `{"rate": "0.8548…"}`.
- Sets `Accept: application/json` and a `User-Agent: finance-quote-unirate/0.01` header on the request — the upstream sits behind Cloudflare, which 403s the default `libwww-perl/X.YZ` UA. (Same workaround pattern as the headers added to `MarketWatch.pm` for issue #542.)
- API key is read from the `unirate` hash inside `currency_rates` only — no env-var fallback, consistent with the comment in `CurrencyFreaks.pm` that env-var fallback is reserved for the legacy modules.
- Small-rate inverse path matches the `CurrencyFreaks` / `AlphaVantage` shape (`if ($rate < 0.001) { ... }`).

Happy to fold in any review feedback — naming, error handling, additional test pairs, etc.
