### PR TITLE
Tradegate.pm: trim whitespace before parsing date and time

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{$NEXT}}
+	* Tradegate.pm: trim whitespace before parsing date and time
+
 	* Added CurrencyRates/Frankfurter
 	* Removed AEX.pm - Euronext.com added JavaScript based anti-webscraping.
 	* Added CurrencyRates/UniRate.pm.

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1176,7 +1176,7 @@
 - module: Tradegate.pm
   state: working
   added: 2022-10-19
-  changed: 2025-02-05
+  changed: 2026-06-10
   removed: ~
   urls:
     - https://web.s-investor.de/app/aktien.htm?INST_ID=0000057

--- a/lib/Finance/Quote/Tradegate.pm
+++ b/lib/Finance/Quote/Tradegate.pm
@@ -26,7 +26,7 @@ use if DEBUG, 'Smart::Comments';
 use LWP::UserAgent;
 use Web::Scraper;
 
-# VERSION
+our $VERSION = '1.69'; # VERSION
 
 my $TRADEGATE_URL = 'https://web.s-investor.de/app/detail.htm?boerse=TDG&isin=';
 
@@ -100,8 +100,10 @@ sub tradegate {
 
         $td1 = ($lastvalue->look_down('_tag'=>'td'))[7];
         @child = $td1->content_list;
-        my $date = substr($child[0], 0, 8);
-        my $time = substr($child[0], 9, 5); # CE(S)T
+        my $raw = $child[0];
+        $raw =~ s/^\s+|\s+$//g;
+        my $date = substr($raw, 0, 8);
+        my $time = substr($raw, 9, 5); # CE(S)T
 
         $td1 = ($lastvalue->look_down('_tag'=>'td'))[9];
         @child = $td1->content_list;


### PR DESCRIPTION
The date/time field from s-investor.de can contain leading or trailing
whitespace. Using substr() directly on the raw value then produces a
wrong result (e.g. wrong year).

Fix: extract to $raw first, trim whitespace, then apply substr().

Similar to the fix applied to Sinvestor.pm and XETRA.pm in PR #557.