### PR TITLE
Fix tab indentation in Modules-README.yml (Union.pm entry)

### DIFF
--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -1381,12 +1381,12 @@
   changed: 2025-10-21
   removed: ~
   urls: https://internal.api.union-investment.de/beta/web/funddata/fundsearch?segment=web_de&type=fondssuche&api-version=beta-2.0.0
-	methods:
+  methods:
     - unionfunds
   apikey: false
   notes: |
-		search symbol has changed from WKN to ISIN
-		See the module source for the required API Key.
+    search symbol has changed from WKN to ISIN
+    See the module source for the required API Key.
   testfile: union.t
   testcases:
     - DE0008491002


### PR DESCRIPTION
### Problem
`Modules-README.yml` does not parse as YAML. The `Union.pm` entry uses **tab characters** to indent its `methods:` key and the content of its `notes:` block. YAML forbids tabs for indentation, so any YAML loader fails.  

### Fix
Replace the tabs with spaces (2-space for the key, 4-space for the `notes` block content), matching the convention used by every other entry in the file. No data changed.
