### PR TITLE
Tradegate.pm: fix duplicate $VERSION declaration

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,9 @@
 {{$NEXT}}
+	* Tradegate.pm: remove explicit "our $VERSION" assignment that collided
+	  with the dzil-injected version, producing a duplicate declaration and
+	  an "our variable $VERSION redeclared" warning. Use a bare # VERSION
+	  marker like the other modules.
+
 	* Tradegate.pm: trim whitespace before parsing date and time
 
 	* Added CurrencyRates/Frankfurter

--- a/lib/Finance/Quote/Tradegate.pm
+++ b/lib/Finance/Quote/Tradegate.pm
@@ -26,7 +26,7 @@ use if DEBUG, 'Smart::Comments';
 use LWP::UserAgent;
 use Web::Scraper;
 
-our $VERSION = '1.69'; # VERSION
+# VERSION
 
 my $TRADEGATE_URL = 'https://web.s-investor.de/app/detail.htm?boerse=TDG&isin=';
 


### PR DESCRIPTION
Tradegate.pm declared an explicit "our $VERSION = '1.69';" on the same line as the "# VERSION" marker. At build time dzil's [OurPkgVersion] injects its own "our $VERSION" at that marker, producing two declarations on one line:

  our $VERSION = '1.69'; our $VERSION = '1.21'; # VERSION

This emits an "our variable $VERSION redeclared" warning at load time, which GnuCash surfaces as a Finance::Quote check error. Use a bare "# VERSION" marker like every other module so dzil injects a single declaration.