### PR TITLE
Fix ukfunds

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* FTfunds.pm: added useragent, cloned from BVB.pm.
 
 1.70      2026-06-21 11:34:56-07:00 America/Los_Angeles
 	* New module, Finnhub.pm. Fetches quotes from https://finnhub.io using a free personal-use API key.

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -609,7 +609,7 @@
 - module: FTfunds.pm
   state: working
   added: 2014-03-02
-  changed: 2023-04-09
+  changed: 2026-07-20
   removed: ~
   urls:
     - https://markets.ft.com/data/funds/tearsheet/summary?s=
@@ -941,7 +941,7 @@
     - 2002013108
 #
 - module: MorningstarUK.pm
-  state: working
+  state: failing
   added: TBD
   changed: 2025-07-16
   removed: ~

--- a/lib/Finance/Quote/FTfunds.pm
+++ b/lib/Finance/Quote/FTfunds.pm
@@ -132,9 +132,14 @@ sub ftfunds_fund  {
 
 # perform the look-up - if not found, return with error
 
+	my @ua_headers = (
+		'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36',
+		'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+	);
+
 # try listed funds first...
 
-		my $webdoc  = $ua->get($FTFUNDS_LOOK_LD.$code);
+		my $webdoc  = $ua->get($FTFUNDS_LOOK_LD.$code, @ua_headers);
     	if (!$webdoc->is_success)
 		{
 	        # serious error, report it and give up
@@ -157,7 +162,7 @@ DEBUG and print "\nStatus = ",$webdoc->status_line, "\n";
         m[<h2>(0 results)</h2>] )
     	{
 DEBUG and print "\nTrying unlisted funds for ",$code," : ",$1,"\n";
-			$webdoc  = $ua->get($FTFUNDS_LOOK_UD.$code);
+			$webdoc  = $ua->get($FTFUNDS_LOOK_UD.$code, @ua_headers);
 			if (!$webdoc->is_success)
         	{
 	        	# serious error, report it and give up


### PR DESCRIPTION
ukfunds seems to have been broken since some time last week, meaning both FTfunds and MorningstarUK are not working.

FTfunds was returning a 403 error but I was able to get around this by using the useragent string from BVB.pm.

MorningstarUK looks to be needing a more serious intervention that is beyond my current skillset.