### PR TITLE
IndiaMutual: update AMFI NAV file parsing to 8-column format

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+	* IndiaMutual.pm: Update AMFI NAV file parsing to 8-column format with Plan and Option fields.
 	* Removed MorningstarCH.pm - Issue #582
 	* Removed MorningstarUK.pm - Issue #579
 	* IndiaMutual.pm: Add support for SIF quotes from AMFI.

--- a/Modules-README.yml
+++ b/Modules-README.yml
@@ -843,10 +843,10 @@
 - module: IndiaMutual.pm
   state: working
   added: TBD
-  changed: 2026-08-03
+  changed: 2026-08-20
   removed: ~
   urls:
-    - https://www.amfiindia.com/spages/NAVAll.txt
+    - https://portal.amfiindia.com/spages/NAVAll.txt
     - https://portal.amfiindia.com/spages/SIF_NAVAll.txt
   apikey: false
   notes: ~

--- a/lib/Finance/Quote/IndiaMutual.pm
+++ b/lib/Finance/Quote/IndiaMutual.pm
@@ -37,11 +37,11 @@ use IO::String;
 # URLs of where to obtain information.
 
 $AMFI_MAIN_URL = ("http://www.amfiindia.com/");
-$AMFI_URL = ("https://www.amfiindia.com/spages/NAVAll.txt");
+$AMFI_URL = ("https://portal.amfiindia.com/spages/NAVAll.txt");
 $AMFI_SIF_URL = ("https://portal.amfiindia.com/spages/SIF_NAVAll.txt");
 
 our $DISPLAY    = 'IndiaMutual - Assoc of Mutual Funds in India';
-our @LABELS     = qw/method source link name currency date isodate nav/;
+our @LABELS     = qw/method source link name currency date isodate nav plan option/;
 our $METHODHASH = {subroutine => \&amfiindia, 
                    display    => $DISPLAY, 
                    labels     => \@LABELS};
@@ -100,7 +100,7 @@ sub amfiindia   {
         my $output = $reply->content;
         my @array = split("\n", $output);
 
-        # Scheme Code;ISIN Div Payout/ ISIN Growth;ISIN Div Reinvestment;Scheme Name;Net Asset Value;Date
+        # Scheme Code;ISIN Div Payout/ ISIN Growth;ISIN Div Reinvestment;Scheme Name;Plan;Option;Net Asset Value;Date
         # Note it is best to use Scheme Code as not all rows have ISINs in the source file
         foreach (@array) {
             next if !/\;/;
@@ -108,19 +108,22 @@ sub amfiindia   {
             s/\r//;
 
             my @words = split(";", $_);					#the delimiter is ; not a ,
+            next unless @words >= 8;
 
             foreach my $sym ($words[0], $words[1], $words[2]) {
                 next unless defined $sym && length($sym) && $sym ne '-';
                 if (exists $symbolhash{$sym} && ! exists $fundquote{$sym, "success"}) {
-                    $fundquote{$sym, "symbol"} = $sym;
+                    $fundquote{$sym, "symbol"}   = $sym;
                     $fundquote{$sym, "currency"} = "INR";
-                    $fundquote{$sym, "source"} = $AMFI_MAIN_URL;
-                    $fundquote{$sym, "link"} = $url;
-                    $fundquote{$sym, "method"} = "amfiindia";
-                    $fundquote{$sym, "name"} = $words[3];
-                    $fundquote{$sym, "nav"} = $words[4];
-                    $quoter->store_date(\%fundquote, $sym, {eurodate => $words[5]});
-                    $fundquote{$sym, "success"} = 1;
+                    $fundquote{$sym, "source"}   = $AMFI_MAIN_URL;
+                    $fundquote{$sym, "link"}     = $url;
+                    $fundquote{$sym, "method"}   = "amfiindia";
+                    $fundquote{$sym, "name"}     = $words[3];
+                    $fundquote{$sym, "plan"}     = $words[4] if defined $words[4] && length $words[4];
+                    $fundquote{$sym, "option"}   = $words[5] if defined $words[5] && length $words[5];
+                    $fundquote{$sym, "nav"}      = $words[6];
+                    $quoter->store_date(\%fundquote, $sym, {eurodate => $words[7]});
+                    $fundquote{$sym, "success"}  = 1;
                 }
             }
         }
@@ -187,6 +190,10 @@ Information available from amfiindia may include the following labels:
 =item currency
 
 =item nav
+
+=item plan
+
+=item option
 
 =back
 


### PR DESCRIPTION
Update `IndiaMutual.pm` to handle the 8-column AMFI NAV file format (`NAVAll.txt` and `SIF_NAVAll.txt`), which added `Plan` and `Option` fields.

- Extract `nav` from column 6 and `date` from column 7.
- Add optional `plan` and `option` return fields.
- Update `$AMFI_URL` to portal URL.
- Update `Changes` file.